### PR TITLE
Add time stamp delay parameter

### DIFF
--- a/white_balancer/cfg/white_balancer.cfg
+++ b/white_balancer/cfg/white_balancer.cfg
@@ -6,6 +6,6 @@ from dynamic_reconfigure.parameter_generator_catkin import ParameterGenerator, i
 gen = ParameterGenerator()
 
 gen.add("temp", int_t, 1, "Color temp for white balance.", min=1000, max=12000)
-gen.add("delay", double_t, 1, "Delay the image time stamp by that value.", min=-2.0, max=2.0)
+gen.add("timestamp_offset", double_t, 1, "Substracts an offset from the image timestamp.", min=-2.0, max=2.0)
 
 exit(gen.generate("white_balancer", "white_balancer", "WhiteBalance"))

--- a/white_balancer/cfg/white_balancer.cfg
+++ b/white_balancer/cfg/white_balancer.cfg
@@ -6,6 +6,6 @@ from dynamic_reconfigure.parameter_generator_catkin import ParameterGenerator, i
 gen = ParameterGenerator()
 
 gen.add("temp", int_t, 1, "Color temp for white balance.", min=1000, max=12000)
-gen.add("timestamp_offset", double_t, 1, "Substracts an offset from the image timestamp.", min=-2.0, max=2.0)
+gen.add("timestamp_offset", double_t, 1, "Adds an offset (Seconds) from the image timestamp.", min=-2.0, max=2.0)
 
 exit(gen.generate("white_balancer", "white_balancer", "WhiteBalance"))

--- a/white_balancer/cfg/white_balancer.cfg
+++ b/white_balancer/cfg/white_balancer.cfg
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
 # configuration
 
-from dynamic_reconfigure.parameter_generator_catkin import ParameterGenerator, int_t
+from dynamic_reconfigure.parameter_generator_catkin import ParameterGenerator, int_t, double_t
 
 gen = ParameterGenerator()
 
 gen.add("temp", int_t, 1, "Color temp for white balance.", min=1000, max=12000)
+gen.add("delay", double_t, 1, "Delay the image time stamp by that value.", min=-2.0, max=2.0)
 
 exit(gen.generate("white_balancer", "white_balancer", "WhiteBalance"))

--- a/white_balancer/config/config.yaml
+++ b/white_balancer/config/config.yaml
@@ -1,6 +1,6 @@
 temp: 2823 #Kelvin
 
-timestamp_offset: 0.1 #Image timestamp offset
+timestamp_offset: -0.1 #Image timestamp offset
 
 ROS_input_topic: "/image_resized"
 

--- a/white_balancer/config/config.yaml
+++ b/white_balancer/config/config.yaml
@@ -1,5 +1,7 @@
 temp: 2823 #Kelvin
 
+delay: 0.1 #Image time stamp delay
+
 ROS_input_topic: "/image_resized"
 
 ROS_output_topic: "/image_raw"

--- a/white_balancer/config/config.yaml
+++ b/white_balancer/config/config.yaml
@@ -1,6 +1,6 @@
 temp: 2823 #Kelvin
 
-delay: 0.1 #Image time stamp delay
+timestamp_offset: 0.1 #Image timestamp offset
 
 ROS_input_topic: "/image_resized"
 

--- a/white_balancer/src/white_balancer.cpp
+++ b/white_balancer/src/white_balancer.cpp
@@ -133,7 +133,7 @@ private:
     // Dummy color
     int temp = 1000;
     // Time stamp delay
-    float delay = 0.1;
+    ros::Duration timestamp_offset = ros::Duration(0.0);
     // Image calback
     void imageCallback(const sensor_msgs::ImageConstPtr& msg);
     void set_temp(int temp);
@@ -178,14 +178,15 @@ void WhiteBalancer::set_temp(int temp)
     WhiteBalancer::temp = 100 * ((int) temp / 100);
 }
 
-void WhiteBalancer::set_delay(double delay)
+void WhiteBalancer::set_delay(double timestamp_offset)
 {
-    // Check delay diff
-    if (WhiteBalancer::delay != delay) 
+    ros::Duration timestamp_offset_duration = ros::Duration(timestamp_offset);
+    // Check timestamp offset diff
+    if (WhiteBalancer::timestamp_offset != timestamp_offset_duration) 
     {
-        // Set delay
-        WhiteBalancer::delay = delay;
-        ROS_INFO("Set new image timestamp delay '%f sec'!", delay);
+        // Set timestamp offset
+        WhiteBalancer::timestamp_offset = timestamp_offset_duration;
+        ROS_INFO("Set new image timestamp delay '%f sec'!", timestamp_offset);
     }
 }
 
@@ -203,7 +204,7 @@ void WhiteBalancer::imageCallback(const sensor_msgs::ImageConstPtr& msg)
                                                 (float)(255.0/white_value[1]),
                                                 (float)(255.0/white_value[0])), cv_ptr->image);
         
-        cv_ptr->header.stamp = cv_ptr->header.stamp - ros::Duration(WhiteBalancer::delay);
+        cv_ptr->header.stamp = cv_ptr->header.stamp - WhiteBalancer::timestamp_offset;
 
         // Publish white balanced image
         WhiteBalancer::pub.publish(cv_ptr->toImageMsg());
@@ -219,7 +220,7 @@ void WhiteBalancer::callbackRC(white_balancer::WhiteBalanceConfig &config, uint3
     // Set color temperature
     WhiteBalancer::set_temp(config.temp);
     // Set timestamp delay
-    WhiteBalancer::set_delay(config.delay);
+    WhiteBalancer::set_delay(config.timestamp_offset);
 }
   
 int main(int argc, char **argv)

--- a/white_balancer/src/white_balancer.cpp
+++ b/white_balancer/src/white_balancer.cpp
@@ -204,7 +204,7 @@ void WhiteBalancer::imageCallback(const sensor_msgs::ImageConstPtr& msg)
                                                 (float)(255.0/white_value[1]),
                                                 (float)(255.0/white_value[0])), cv_ptr->image);
         
-        cv_ptr->header.stamp = cv_ptr->header.stamp - WhiteBalancer::timestamp_offset;
+        cv_ptr->header.stamp = cv_ptr->header.stamp + WhiteBalancer::timestamp_offset;
 
         // Publish white balanced image
         WhiteBalancer::pub.publish(cv_ptr->toImageMsg());


### PR DESCRIPTION
To fix the timing issue with the Basler cam timings I integrated a time delay parameter in the white balancer.
The Parameter can be easily be changed via dynamic reconfigure.