### PR TITLE
Switches from normal to convex field boundy for ball filtering.

### DIFF
--- a/bitbots_vision/src/bitbots_vision/vision.py
+++ b/bitbots_vision/src/bitbots_vision/vision.py
@@ -114,7 +114,7 @@ class Vision:
         ball_candidates = self.ball_detector.get_candidates()
 
         if ball_candidates:
-            balls_under_field_boundary = self.field_boundary_detector.balls_under_field_boundary(ball_candidates)
+            balls_under_field_boundary = self.field_boundary_detector.balls_under_convex_field_boundary(ball_candidates)
             if balls_under_field_boundary:
                 sorted_rated_candidates = sorted(balls_under_field_boundary, key=lambda x: x.rating)
                 top_ball_candidate = list([max(sorted_rated_candidates[0:1], key=lambda x: x.rating)])[0]

--- a/bitbots_vision/src/bitbots_vision/vision_modules/field_boundary.py
+++ b/bitbots_vision/src/bitbots_vision/vision_modules/field_boundary.py
@@ -633,10 +633,10 @@ class FieldBoundaryDetector:
         :param offset: offset of pixels to still be accepted as under the field_boundary. Default is 0.
         :return a boolean if point is under field_boundary:
         """
-        if not 0 <= point[0] < len(self.get_full_field_boundary()):
+        if not 0 <= point[0] < len(self.get_full_convex_field_boundary()):
             rospy.logwarn('point_under_field_boundary got called with an out of bounds field_boundary point')
             return False
-        return point[1] + offset > self.get_full_field_boundary()[point[0]]
+        return point[1] + offset > self.get_full_convex_field_boundary()[point[0]]
 
     def get_upper_bound(self, y_offset=0):
         # type: () -> int

--- a/bitbots_vision/src/bitbots_vision/vision_modules/field_boundary.py
+++ b/bitbots_vision/src/bitbots_vision/vision_modules/field_boundary.py
@@ -608,6 +608,17 @@ class FieldBoundaryDetector:
         footpoint = (candidate[0] + candidate[2] // 2, candidate[1] + candidate[3] + y_offset)
         return self.point_under_field_boundary(footpoint)
 
+    def candidate_under_convex_field_boundary(self, candidate, y_offset=0):
+        # type: (tuple, int) -> bool
+        """
+        returns whether the candidate is under the convex field_boundary or not
+        :param candidate: the candidate, a tuple (upleft_x, upleft_y, width, height)
+        :param y_offset: an offset in y-direction (higher offset allows points in a wider range over the field_boundary)
+        :return: whether the candidate is under the convex field_boundary or not
+        """
+        footpoint = (candidate[0] + candidate[2] // 2, candidate[1] + candidate[3] + y_offset)
+        return self.point_under_convex_field_boundary(footpoint)
+
     def compute_all(self):
         self.compute_full_convex_field_boundary()
         self.compute_full_field_boundary()
@@ -616,9 +627,22 @@ class FieldBoundaryDetector:
         # type: (list, int) -> list
         return [candidate for candidate in candidates if self.candidate_under_field_boundary(candidate, y_offset)]
 
+    def candidates_under_convex_field_boundary(self, candidates, y_offset=0):
+        # type: (list, int) -> list
+        return [candidate for candidate in candidates if self.candidate_under_convex_field_boundary(candidate, y_offset)]
+
     def balls_under_field_boundary(self, balls, y_offset=0):
         # type: (list, int) -> list
         return [candidate for candidate in balls if self.candidate_under_field_boundary(
+            (candidate.get_upper_left_x(),
+             candidate.get_upper_left_y(),
+             candidate.get_width(),
+             candidate.get_height()),
+            y_offset)]
+
+    def balls_under_convex_field_boundary(self, balls, y_offset=0):
+        # type: (list, int) -> list
+        return [candidate for candidate in balls if self.candidate_under_convex_field_boundary(
             (candidate.get_upper_left_x(),
              candidate.get_upper_left_y(),
              candidate.get_width(),
@@ -632,6 +656,19 @@ class FieldBoundaryDetector:
         :param point: coordinate (x, y) to test
         :param offset: offset of pixels to still be accepted as under the field_boundary. Default is 0.
         :return a boolean if point is under field_boundary:
+        """
+        if not 0 <= point[0] < len(self.get_full_field_boundary()):
+            rospy.logwarn('point_under_field_boundary got called with an out of bounds field_boundary point')
+            return False
+        return point[1] + offset > self.get_full_field_boundary()[point[0]]
+
+    def point_under_convex_field_boundary(self, point, offset=0):
+        # type: (tuple, int) -> bool
+        """
+        returns if given coordinate is a point under the convex field_boundary
+        :param point: coordinate (x, y) to test
+        :param offset: offset of pixels to still be accepted as under the field_boundary. Default is 0.
+        :return a boolean if point is under the convex field_boundary:
         """
         if not 0 <= point[0] < len(self.get_full_convex_field_boundary()):
             rospy.logwarn('point_under_field_boundary got called with an out of bounds field_boundary point')


### PR DESCRIPTION
In the reversed field boundary search method the ball often gets detected as a part of the field boundary.
The vision drops balls above the field boundary. Unfortunately, the ball gets dropped most of the time, because the field boundary goes around it. To fix this, I use the convex field boundary to determine if the ball is on our field.