### PR TITLE
Turn off line detection

### DIFF
--- a/bitbots_vision/cfg/Vision.cfg
+++ b/bitbots_vision/cfg/Vision.cfg
@@ -114,9 +114,8 @@ group_obstacle_detector.add("obstacle_candidate_max_width", int_t, 0, "obstacle_
 group_obstacle_detector.add("obstacle_finder_step_length", int_t, 0, "obstacle_finder_step_length", min=1, max=640)
 group_obstacle_detector.add("obstacle_finder_value_increase", double_t, 0, "obstacle_finder_value_increase", min=0, max=10.0)
 
-
 group_line_detector.add("line_detector_field_boundary_offset", int_t, 0, "line_detector_field_boundary_offset", min=0, max=200)
-group_line_detector.add("line_detector_linepoints_range", int_t, 0, "line_detector_linepoints_range", min=200, max=20000)
+group_line_detector.add("line_detector_linepoints_range", int_t, 0, "line_detector_linepoints_range", min=0, max=20000)
 group_line_detector.add("line_detector_blur_kernel_size", int_t, 0, "line_detector_blur_kernel_size", min=1, max=30)
 
 group_ROS.add("ROS_img_msg_topic", str_t, 0, "ROS_img_msg_topic", None)

--- a/bitbots_vision/config/visionparams.yaml
+++ b/bitbots_vision/config/visionparams.yaml
@@ -62,7 +62,7 @@ vision_ball_candidate_rating_threshold: 0.5
 vision_debug_printer_classes: ''
 
 line_detector_field_boundary_offset: 15
-line_detector_linepoints_range: 200
+line_detector_linepoints_range: 0
 line_detector_blur_kernel_size: 9
 
 obstacle_finder_method: 'convex'  # distance, convex or step


### PR DESCRIPTION
Turn off line detection by creating zero line points.
Currently line points are not needed for further processing, therefore some resources can be saved.

#36 is a reminder to reset this to default.