### PR TITLE
Add camera parameter to launch file

### DIFF
--- a/bitbots_vision/launch/vision_startup.launch
+++ b/bitbots_vision/launch/vision_startup.launch
@@ -1,9 +1,10 @@
 <launch>
     <arg name="sim" default="false" />
+    <arg name="camera" default="true" />
+    <arg name="basler" default="true" />
     <arg name="dummyball" default="false" />
     <arg name="debug" default="false" />
     <arg name="use_game_settings" default="false" />
-    <arg name="basler" default="true" />
 
     <!-- start vision for wolfgang (fcnn)-->
     <group unless="$(arg dummyball)">
@@ -35,7 +36,7 @@
     </node>
 
     <!-- start the camera only when necessary -->
-    <group unless="$(arg sim)">
+    <group if="$(arg camera)">
         <include unless="$(arg basler)" file="$(find wolves_image_provider)/launch/image_provider.launch" />
         <include if="$(arg basler)" file="$(find bitbots_bringup)/launch/basler_camera.launch" />
     </group>

--- a/bitbots_vision/launch/vision_startup.launch
+++ b/bitbots_vision/launch/vision_startup.launch
@@ -1,36 +1,38 @@
 <launch>
-    <arg name="sim" default="false"/>
-    <arg name="dummyball" default="false"/>
-    <arg name="debug" default="false"/>
-    <arg name="use_game_settings" default="false"/>
+    <arg name="sim" default="false" />
+    <arg name="dummyball" default="false" />
+    <arg name="debug" default="false" />
+    <arg name="use_game_settings" default="false" />
     <arg name="basler" default="true" />
 
     <!-- start vision for wolfgang (fcnn)-->
     <group unless="$(arg dummyball)">
         <node pkg="bitbots_vision" type="vision.py" name="bitbots_vision" output="screen">
-            <rosparam command="load" file="$(find bitbots_vision)/config/visionparams.yaml"/>
+            <rosparam command="load" file="$(find bitbots_vision)/config/visionparams.yaml" />
             <param name="vision_ball_classifier" value="fcnn" />
-            <param name="vision_publish_debug_image" value="$(arg debug)"/>
-            <param name="vision_use_sim_color" value="$(arg sim)"/>
+            <param name="vision_use_sim_color" value="$(arg sim)" />
+            <param name="vision_publish_debug_image" value="$(arg debug)" />
         </node>
     </group>
 
     <!-- start vision without balldetection-->
     <group if="$(arg dummyball)">
         <node pkg="bitbots_vision" type="vision.py" name="bitbots_vision" output="screen">
-            <rosparam command="load" file="$(find bitbots_vision)/config/visionparams.yaml"/>
-            <param name="vision_publish_debug_image" value="$(arg debug)"/>
+            <rosparam command="load" file="$(find bitbots_vision)/config/visionparams.yaml" />
             <param name="vision_ball_classifier" value="dummy" />
-            <param name="vision_use_sim_color" value="$(arg sim)"/>
+            <param name="vision_use_sim_color" value="$(arg sim)" />
+            <param name="vision_publish_debug_image" value="$(arg debug)" />
         </node>
     </group>
 
+    <!-- load game settings -->
     <group if="$(arg use_game_settings)">
         <rosparam command="load" file="$(find bitbots_bringup)/config/game_settings.yaml" />
     </group>
 
     <!-- start dynamic-color-space node -->
-    <node pkg="bitbots_vision" type="dynamic_color_space.py" name="bitbots_dynamic_color_space" output="screen"></node>
+    <node pkg="bitbots_vision" type="dynamic_color_space.py" name="bitbots_dynamic_color_space" output="screen">
+    </node>
 
     <!-- start the camera only when necessary -->
     <group unless="$(arg sim)">
@@ -38,9 +40,9 @@
         <include if="$(arg basler)" file="$(find bitbots_bringup)/launch/basler_camera.launch" />
     </group>
 
-    <!-- remap stuff to fit the robot -->
+    <!-- set use simulation time -->
     <group if="$(arg sim)">
-        <param name="use_sim_time" value="true"/>
+        <param name="use_sim_time" value="true" />
     </group>
 
 </launch>

--- a/bitbots_vision/launch/vision_startup.launch
+++ b/bitbots_vision/launch/vision_startup.launch
@@ -1,10 +1,10 @@
 <launch>
-    <arg name="sim" default="false" doc="activates simulation time and switches to simulation color settings" />
-    <arg name="camera" default="true" doc="launches an image provider to get camera images" />
-    <arg name="basler" default="true" doc="launches the basler camera driver instead of the wolves image provider" />
-    <arg name="dummyball" default="false" doc="does not start the ball detection to save resouces" />
-    <arg name="debug" default="false" doc="activates publishing of several debug images" />
-    <arg name="use_game_settings" default="false" doc="loads additional game settings" />
+    <arg name="sim" default="false" doc="true: activates simulation time and switches to simulation color settings" />
+    <arg name="camera" default="true" doc="true: launches an image provider to get images from a camera" />
+    <arg name="basler" default="true" doc="true: launches the basler camera driver instead of the wolves image provider" />
+    <arg name="dummyball" default="false" doc="true: does not start the ball detection to save resources" />
+    <arg name="debug" default="false" doc="true: activates publishing of several debug images" />
+    <arg name="use_game_settings" default="false" doc="true: loads additional game settings" />
 
     <!-- start vision for wolfgang (fcnn)-->
     <group unless="$(arg dummyball)">

--- a/bitbots_vision/launch/vision_startup.launch
+++ b/bitbots_vision/launch/vision_startup.launch
@@ -1,10 +1,10 @@
 <launch>
-    <arg name="sim" default="false" />
-    <arg name="camera" default="true" />
-    <arg name="basler" default="true" />
-    <arg name="dummyball" default="false" />
-    <arg name="debug" default="false" />
-    <arg name="use_game_settings" default="false" />
+    <arg name="sim" default="false" doc="activates simulation time and switches to simulation color settings" />
+    <arg name="camera" default="true" doc="launches an image provider to get camera images" />
+    <arg name="basler" default="true" doc="launches the basler camera driver instead of the wolves image provider" />
+    <arg name="dummyball" default="false" doc="does not start the ball detection to save resouces" />
+    <arg name="debug" default="false" doc="activates publishing of several debug images" />
+    <arg name="use_game_settings" default="false" doc="loads additional game settings" />
 
     <!-- start vision for wolfgang (fcnn)-->
     <group unless="$(arg dummyball)">

--- a/bitbots_vision/launch/vision_startup.launch
+++ b/bitbots_vision/launch/vision_startup.launch
@@ -13,6 +13,9 @@
             <param name="vision_ball_classifier" value="fcnn" />
             <param name="vision_use_sim_color" value="$(arg sim)" />
             <param name="vision_publish_debug_image" value="$(arg debug)" />
+            <param name="vision_publish_field_mask_image" value="$(arg debug)" />
+            <param name="dynamic_color_space_publish_field_mask_image" value="$(arg debug)" />
+            <!-- also add fcnn handler debug image parameter when available -->
         </node>
     </group>
 
@@ -23,6 +26,9 @@
             <param name="vision_ball_classifier" value="dummy" />
             <param name="vision_use_sim_color" value="$(arg sim)" />
             <param name="vision_publish_debug_image" value="$(arg debug)" />
+            <param name="vision_publish_field_mask_image" value="$(arg debug)" />
+            <param name="dynamic_color_space_publish_field_mask_image" value="$(arg debug)" />
+            <!-- also add fcnn handler debug image parameter when available -->
         </node>
     </group>
 


### PR DESCRIPTION
This adds a new `camera` parameter to launch file. This parameter determines wether an image provider will be launched (as the `sim` parameter before).

This changes also the behavior of the `debug` parameter: if true, this also activates the publishing of several image messages such as field masks.