### PR TITLE
dynamic reconfigure: generate enums for models and color spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@ README
 ======
 
 This is the vision package of the Hamburg Bit-Bots.
-For standardized camers such as USB-webcams we use the wolves_image_provider package as image provider.
+For standardized cameras such as USB-webcams we use the wolves_image_provider package as image provider.
 Alternatively every image source, that publishes sensor_msgs/Image messages (i.e. basler driver for basler cameras) is supported.
 Settings considering the vision are set in the visionparams.yaml (bitbots_vision/config/visionparams.yaml).
 You do NOT want to enable DEBUG on the robot.
 The color calibration files are created with the wolves colorpicker and a rosbag.
 The source code of the vision is located in bitbots_vision/src.
 In bitbots_vision/models the fcnn models are stored. Due to their size, these are not part of this repository.
+After changes in the models or config/color_spaces directory, rebuilding the vision node is required to see these changes in dynamic reconfigure.
 To tweak the camera image, use the settings in the image provider.
 
 Neural Network Models

--- a/bitbots_vision/cfg/Vision.cfg
+++ b/bitbots_vision/cfg/Vision.cfg
@@ -2,6 +2,11 @@
 PACKAGE = "bitbots_vision"
 
 from dynamic_reconfigure.parameter_generator_catkin import *
+import os
+import rospkg
+
+rospack = rospkg.RosPack()
+package_path = rospack.get_path('bitbots_vision')
 
 gen = ParameterGenerator()
 
@@ -20,6 +25,13 @@ obstacle_detector_enum = gen.enum([ gen.const("convex",      str_t, "convex", "f
                        gen.const("step",      str_t, "step", "finds obstacles using the height difference of the normal field boundary")],
                      "An enum to change the obstacle detector method")
 
+color_spaces_path = os.path.join(package_path, "config/color_spaces")
+color_space_files = [file for file in os.listdir(color_spaces_path) if os.path.isfile(os.path.join(color_spaces_path, file))]
+field_color_space_enum = gen.enum([gen.const(cs_file.replace(".", "_"), str_t, cs_file, "loads the colorspace file at %s" % cs_file) for cs_file in color_space_files],
+                     "An enum to select a field color space file")
+
+fcnn_paths = os.listdir(os.path.join(package_path, "models"))
+fcnn_paths_enum = gen.enum([gen.const(path, str_t, path, "fcnn %s" % path) for path in fcnn_paths], "An enum to select a fcnn model")
 
 group_vision = gen.add_group("vision", type="tab")
 group_ROS = gen.add_group("ROS", type="tab")
@@ -40,7 +52,7 @@ group_white_color_detector = group_color_detector.add_group("white_color_detecto
 group_red_color_detector = group_color_detector.add_group("red_color_detector")
 group_blue_color_detector = group_color_detector.add_group("blue_color_detector")
 
-group_ball_fcnn.add("ball_fcnn_model_path", str_t, 0, "ball_fcnn_model_path", None)
+group_ball_fcnn.add("ball_fcnn_model_path", str_t, 0, "ball_fcnn_model_path", fcnn_paths[0], edit_method=fcnn_paths_enum)
 group_ball_fcnn.add("ball_fcnn_debug", bool_t, 0, "ball_fcnn_debug", None)
 group_ball_fcnn.add("ball_fcnn_threshold", double_t, 0, "ball_fcnn_threshold", min=0.0, max=1.0)
 group_ball_fcnn.add("ball_fcnn_expand_stepsize", int_t, 0, "ball_fcnn_expand_stepsize", min=1, max=20)
@@ -52,8 +64,8 @@ group_ball_fcnn.add("ball_fcnn_candidate_refinement_iteration_count", int_t, 0, 
 group_ball_fcnn.add("ball_fcnn_publish_output", bool_t, 0, "publish the output of the ball fcnn as ImageWithCorners", None)
 group_ball_fcnn.add("ball_fcnn_publish_field_boundary_offset", int_t, 0, "the offset added to the field_boundary when cropping the fcnn output for publication in pixels", min=1,max=50)
 
-group_field_color_detector.add("field_color_detector_path", str_t, 0, "field_color_detector_path", None)
-group_field_color_detector.add("field_color_detector_path_sim", str_t, 0, "field_color_detector_path_sim", None)
+group_field_color_detector.add("field_color_detector_path", str_t, 0, "field_color_detector_path", color_space_files[0], edit_method=field_color_space_enum)
+group_field_color_detector.add("field_color_detector_path_sim", str_t, 0, "field_color_detector_path_sim", color_space_files[0],  edit_method=field_color_space_enum)
 group_field_color_detector.add("field_color_detector_use_dummy_green", bool_t, 0, "field_color_detector_use_dummy_green", None)
 group_field_color_detector.add("field_color_detector_dummy_lower_values_h", int_t, 0, "field_color_detector_dummy_lower_values_h", min=0, max=180)
 group_field_color_detector.add("field_color_detector_dummy_lower_values_s", int_t, 0, "field_color_detector_dummy_lower_values_s", min=0, max=255)

--- a/bitbots_vision/config/visionparams.yaml
+++ b/bitbots_vision/config/visionparams.yaml
@@ -1,5 +1,5 @@
 ball_fcnn_debug: false  # only active when true and vision/debug is true, too!
-ball_fcnn_model_path: '/models/2019_05_timon_basler'
+ball_fcnn_model_path: '2019_05_timon_basler'
 ball_fcnn_threshold: .6  # minimal value for a candidate to be considered
 ball_fcnn_expand_stepsize: 4
 ball_fcnn_pointcloud_stepsize: 10
@@ -9,8 +9,8 @@ ball_fcnn_max_ball_diameter: 150
 ball_fcnn_publish_output: false
 ball_fcnn_publish_field_boundary_offset: 5
 
-field_color_detector_path: '/config/color_spaces/GO2019_interpolated.txt'
-field_color_detector_path_sim: '/config/color_spaces/f031new.yaml'
+field_color_detector_path: 'f031_interpolated.yaml'
+field_color_detector_path_sim: 'f031new.yaml'
 field_color_detector_use_hsv_green: false
 field_color_detector_hsv_lower_values_h: 46
 field_color_detector_hsv_lower_values_s: 101

--- a/bitbots_vision/src/bitbots_vision/vision.py
+++ b/bitbots_vision/src/bitbots_vision/vision.py
@@ -445,7 +445,7 @@ class Vision:
             if 'ball_fcnn_model_path' not in self.config or \
                     self.config['ball_fcnn_model_path'] != config['ball_fcnn_model_path'] or \
                     self.config['vision_ball_classifier'] != config['vision_ball_classifier']:
-                ball_fcnn_path = self.package_path + config['ball_fcnn_model_path']
+                ball_fcnn_path = os.path.join(self.package_path, 'models', config['ball_fcnn_model_path'])
                 if not os.path.exists(ball_fcnn_path):
                     rospy.logerr('AAAAHHHH! The specified fcnn model file doesn\'t exist!')
                 self.ball_fcnn = live_fcnn_03.FCNN03(ball_fcnn_path, self.debug_printer)

--- a/bitbots_vision/src/bitbots_vision/vision_modules/color.py
+++ b/bitbots_vision/src/bitbots_vision/vision_modules/color.py
@@ -209,12 +209,12 @@ class PixelListColorDetector(ColorDetector):
 
         self.config = config
 
-        package_path = os.path.join(package_path, 'config/color_spaces')
+        color_space_path = os.path.join(package_path, 'config/color_spaces')
         # concatenate color-path to file containing the accepted colors of base color space
         if self.config['vision_use_sim_color']:
-            self.color_path = os.path.join(package_path, self.config['field_color_detector_path_sim'])
+            self.color_path = os.path.join(color_space_path, self.config['field_color_detector_path_sim'])
         else:
-            self.color_path = os.path.join(package_path, self.config['field_color_detector_path'])
+            self.color_path = os.path.join(color_space_path, self.config['field_color_detector_path'])
 
         # Set publisher to 'ROS_field_mask_image_msg_topic'
         self.imagepublisher = rospy.Publisher(

--- a/bitbots_vision/src/bitbots_vision/vision_modules/color.py
+++ b/bitbots_vision/src/bitbots_vision/vision_modules/color.py
@@ -6,6 +6,7 @@ import time
 import rospy
 import VisionExtensions
 import numpy as np
+import os
 from collections import deque
 from cv_bridge import CvBridge
 from sensor_msgs.msg import Image
@@ -208,18 +209,19 @@ class PixelListColorDetector(ColorDetector):
 
         self.config = config
 
+        package_path = os.path.join(package_path, 'config/color_spaces')
         # concatenate color-path to file containing the accepted colors of base color space
         if self.config['vision_use_sim_color']:
-            self.color_path = package_path + self.config['field_color_detector_path_sim']
+            self.color_path = os.path.join(package_path, self.config['field_color_detector_path_sim'])
         else:
-            self.color_path = package_path + self.config['field_color_detector_path']
+            self.color_path = os.path.join(package_path, self.config['field_color_detector_path'])
 
         # Set publisher to 'ROS_field_mask_image_msg_topic'
         self.imagepublisher = rospy.Publisher(
             self.config['ROS_field_mask_image_msg_topic'],
             Image,
             queue_size=1)
-        
+
         self.color_space = self.init_color_space(self.color_path)
 
     def init_color_space(self, color_path):


### PR DESCRIPTION
As of this Pull Request, enums for dynamic reconfigure are generated automatically to represent the contents of the respective folder. This has the advantage that typos are avoided and a better overview of the possible values is given. The only drawback is that the vision has to be rebuilt whenever a new color space or model is added.
Since a default has to be selected for enums in dynamic reconfigure, I chose the first file in the folder because it will always be overridden by the default value in the YAML configuration.
This Pull Request was done with the help of @JanGut 