### PR TITLE
remove cascade classifier usage from vision

### DIFF
--- a/bitbots_vision/cfg/Vision.cfg
+++ b/bitbots_vision/cfg/Vision.cfg
@@ -26,8 +26,6 @@ group_ROS = gen.add_group("ROS", type="tab")
 group_ball_fcnn = gen.add_group("ball_fcnn", type="tab")
 group_ball_finder = gen.add_group("ball_finder", type="tab")
 group_field_boundary_finder = gen.add_group("field_boundary_finder", type="tab")
-group_classifier_model = gen.add_group("classifier_model", type="tab")
-group_cascade_classifier = gen.add_group("cascade_classifier", type="tab")
 group_detector = gen.add_group("detector", type="tab")
 group_dynamic_color_space = gen.add_group("DynamicColorSpace", type="tab")
 
@@ -139,9 +137,6 @@ group_ball_finder.add("ball_finder_classify_threshold", double_t, 0, "ball_finde
 group_ball_finder.add("ball_finder_scale_factor", double_t, 0, "ball_finder_scale_factor", min=1.0, max=5.0)
 group_ball_finder.add("ball_finder_min_neighbors", int_t, 0, "ball_finder_min_neighbors", min=0, max=10)
 group_ball_finder.add("ball_finder_min_size", int_t, 0, "ball_finder_min_size", min=5, max=100)
-
-group_classifier_model.add("classifier_model_path", str_t, 0, "classifier_model_path", None)
-group_cascade_classifier.add("cascade_classifier_path", str_t, 0, "cascade_classifier_path", None)
 
 group_dynamic_color_space.add("dynamic_color_space_active", bool_t, 0, "Turn dynamic color space ON or OFF", None)
 group_dynamic_color_space.add("dynamic_color_space_publish_field_mask_image", bool_t, 0, "Publish dynamic color space field mask image message for debug purposes", None)

--- a/bitbots_vision/config/visionparams.yaml
+++ b/bitbots_vision/config/visionparams.yaml
@@ -51,7 +51,7 @@ field_boundary_finder_precision_pix: 5
 field_boundary_finder_min_precision_pix: 3
 field_boundary_finder_head_joint_threshold: -0.5
 
-vision_ball_classifier: 'fcnn'  # cascade, fcnn or dummy
+vision_ball_classifier: 'fcnn'  # fcnn or dummy
 vision_debug_image: false
 vision_publish_debug_image: false
 vision_publish_field_mask_image: false
@@ -98,10 +98,6 @@ ball_finder_classify_threshold: 0.5
 ball_finder_scale_factor: 1.1
 ball_finder_min_neighbors: 1
 ball_finder_min_size: 10
-
-classifier_model_path: '/models/classifier_01'
-
-cascade_classifier_path: '/classifier/cascadeNew.xml'
 
 dynamic_color_space_active: true
 dynamic_color_space_publish_field_mask_image: false

--- a/bitbots_vision/src/bitbots_vision/vision.py
+++ b/bitbots_vision/src/bitbots_vision/vision.py
@@ -403,28 +403,6 @@ class Vision:
             self.debug_printer
         )
 
-        # load cascade
-        if config['vision_ball_classifier'] == 'cascade':
-            self.cascade_path = self.package_path + config['cascade_classifier_path']
-            if 'cascade_classifier_path' not in self.config or \
-                    self.config['cascade_classifier_path'] != config['cascade_classifier_path'] or \
-                    self.config['vision_ball_classifier'] != config['vision_ball_classifier']:
-                if os.path.exists(self.cascade_path):
-                    self.cascade = cv2.CascadeClassifier(self.cascade_path)
-                else:
-                    rospy.logerr(
-                        'AAAAHHHH! The specified cascade config file doesn\'t exist!')
-            if 'classifier_model_path' not in self.config or \
-                    self.config['classifier_model_path'] != config['classifier_model_path'] or \
-                    self.config['vision_ball_classifier'] != config['vision_ball_classifier']:
-                self.ball_classifier = live_classifier.LiveClassifier(
-                    self.package_path + config['classifier_model_path'])
-                rospy.logwarn(config['vision_ball_classifier'] + " vision is running now")
-            self.ball_detector = classifier.ClassifierHandler(self.ball_classifier, self.debug_printer)
-
-            self.ball_finder = ball.BallFinder(self.cascade, config, self.debug_printer)
-
-
         # set up ball config for fcnn
         # these config params have domain-specific names which could be problematic for fcnn handlers handling e.g. goal candidates
         # this enables 2 fcnns with different configs.


### PR DESCRIPTION
Since the cascade classifier is not in use anymore, this PR removes the usage (but NOT module) of it.