### PR TITLE
Ball field boundary offset

### DIFF
--- a/bitbots_vision/cfg/Vision.cfg
+++ b/bitbots_vision/cfg/Vision.cfg
@@ -111,7 +111,7 @@ group_vision.add("vision_debug_printer_classes", str_t, 0, "vision_debug_printer
 group_vision.add("vision_parallelize", bool_t, 0, "vision_parallelize", None)
 group_vision.add("vision_use_sim_color", bool_t, 0, "vision_use_sim_color", None)
 group_vision.add("vision_ball_classifier", str_t, 0, "vision_ball_classifier", "fcnn", edit_method=ball_finder_enum)
-group_vision.add("vision_ball_candidate_field_boundary_y_offset", int_t, 0, "vision_ball_candidate_field_boundary_y_offset", min=0, max=20)
+group_vision.add("vision_ball_candidate_field_boundary_y_offset", int_t, 0, "vision_ball_candidate_field_boundary_y_offset", min=0, max=800)
 group_vision.add("vision_ball_candidate_rating_threshold", double_t, 0, "vision_ball_candidate_rating_threshold", min=0.0, max=1.0)
 group_vision.add("vision_blind_threshold", int_t, 0, "vision_blind_threshold", min=0, max=765)
 

--- a/bitbots_vision/src/bitbots_vision/vision.py
+++ b/bitbots_vision/src/bitbots_vision/vision.py
@@ -131,7 +131,7 @@ class Vision:
         ball_candidates = self.ball_detector.get_candidates()
 
         if ball_candidates:
-            balls_under_field_boundary = self.field_boundary_detector.balls_under_convex_field_boundary(ball_candidates)
+            balls_under_field_boundary = self.field_boundary_detector.balls_under_convex_field_boundary(ball_candidates, self._ball_candidate_y_offset)
             if balls_under_field_boundary:
                 sorted_rated_candidates = sorted(balls_under_field_boundary, key=lambda x: x.rating)
                 top_ball_candidate = list([max(sorted_rated_candidates[0:1], key=lambda x: x.rating)])[0]


### PR DESCRIPTION
This is currently untested. It fixes the issue, that the field boundary offset was ignored before when balls were published (even though it was considered in the debug image generation). 
Also it includes a hot fix which allows to ignore the field boundary.