### PR TITLE
Remove unnecessary static methods

### DIFF
--- a/bitbots_vision/src/bitbots_vision/vision_modules/lines.py
+++ b/bitbots_vision/src/bitbots_vision/vision_modules/lines.py
@@ -141,19 +141,18 @@ class LineDetector:
             self._white_mask = self._white_detector.mask_bitwise(possible_line_locations)
         return self._white_mask
 
-    @staticmethod
-    def filter_points_with_candidates(linepoints, candidates):
-        """
-        Filters line points with candidates.
 
-        :param linepoints: Line Points
-        :param candidates: Detected candidates
-        :return: Filtered line points
-        """
-        filtered_linepoints = []
-        for linepoint in linepoints:
-            # TODO: use list comprehension instead of map
-            linepoint_not_in_candidate = [not candidate.point_in_candidate(linepoint) for candidate in candidates]
-            if all(linepoint_not_in_candidate):
-                filtered_linepoints.append(linepoint)
-        return filtered_linepoints
+def filter_points_with_candidates(linepoints, candidates):
+    """
+    Filters line points with candidates.
+
+    :param linepoints: Line Points
+    :param candidates: Detected candidates
+    :return: Filtered line points
+    """
+    filtered_linepoints = []
+    for linepoint in linepoints:
+        linepoint_not_in_candidate = [not candidate.point_in_candidate(linepoint) for candidate in candidates]
+        if all(linepoint_not_in_candidate):
+            filtered_linepoints.append(linepoint)
+    return filtered_linepoints

--- a/bitbots_vision/src/bitbots_vision/vision_modules/yolo_handler.py
+++ b/bitbots_vision/src/bitbots_vision/vision_modules/yolo_handler.py
@@ -157,14 +157,13 @@ class YoloHandlerOpenCV(YoloHandler):
         self.ball_candidates = None
         self.results = None
 
-    @staticmethod
-    def get_output_layers(net):
+    def get_output_layers(self):
         """
         Library stuff
         """
-        layer_names = net.getLayerNames()
+        layer_names = self.net.getLayerNames()
 
-        output_layers = [layer_names[i[0] - 1] for i in net.getUnconnectedOutLayers()]
+        output_layers = [layer_names[i[0] - 1] for i in self.net.getUnconnectedOutLayers()]
 
         return output_layers
 
@@ -196,7 +195,7 @@ class YoloHandlerOpenCV(YoloHandler):
             # Set image
             self.net.setInput(self.blob)
             # Run net
-            self.outs = self.net.forward(YoloHandlerOpenCV.get_output_layers(self.net))
+            self.outs = self.net.forward(self.get_output_layers())
             # Create lists
             class_ids = []
             confidences = []


### PR DESCRIPTION
This pull request removes unnecessary static methods. There are still some `@staticmethod` decorators left, which I thought where quite useful for the code readability and the namespaces. Fixes #89 