### PR TITLE
Params for f031

### DIFF
--- a/bitbots_vision/config/visionparams.yaml
+++ b/bitbots_vision/config/visionparams.yaml
@@ -42,11 +42,11 @@ dynamic_color_space_threshold: 0.6
 dynamic_color_space_kernel_radius: 1
 dynamic_color_space_field_boundary_detector_search_method: 'reversed' # iteration, reversed, binary or dynamic
 
-white_color_detector_lower_values_h: 0
+white_color_detector_lower_values_h: 101
 white_color_detector_lower_values_s: 0
-white_color_detector_lower_values_v: 27
+white_color_detector_lower_values_v: 158
 white_color_detector_upper_values_h: 180
-white_color_detector_upper_values_s: 94
+white_color_detector_upper_values_s: 255
 white_color_detector_upper_values_v: 255
 
 red_color_detector_lower_values_h: 139
@@ -63,13 +63,13 @@ blue_color_detector_upper_values_h: 116
 blue_color_detector_upper_values_s: 255
 blue_color_detector_upper_values_v: 255
 
-field_boundary_detector_search_method: 'dynamic'  # iteration, reversed, binary or dynamic
+field_boundary_detector_search_method: 'reversed'  # iteration, reversed, binary or dynamic
 field_boundary_detector_vertical_steps: 30
 field_boundary_detector_horizontal_steps: 30
 field_boundary_detector_roi_height: 1
 field_boundary_detector_roi_width: 1
 field_boundary_detector_roi_increase: 0.1  # increase of kernel radius per pixel
-field_boundary_detector_green_threshold: 60
+field_boundary_detector_green_threshold: 136
 field_boundary_detector_precision_pix: 5
 field_boundary_detector_min_precision_pix: 3
 field_boundary_detector_head_tilt_threshold: 20


### PR DESCRIPTION
Adds new parameters for f031 with the Basler camera. I think the f031 parameters should be the default values of the `visionparams.yaml` so it is more userfriendly for non-vision people. This would close #25.