### PR TITLE
Add auto build for vision extensions

### DIFF
--- a/bitbots_vision/CMakeLists.txt
+++ b/bitbots_vision/CMakeLists.txt
@@ -40,3 +40,16 @@ include_directories(
 
 set (CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall")
+
+
+add_custom_target(
+    extensions
+    ALL
+)
+
+add_custom_command(
+    TARGET extensions
+    COMMAND python3 ${CMAKE_SOURCE_DIR}/../python_extensions/setup.py ARGS build install "--user"
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/../python_extensions/
+)
+

--- a/bitbots_vision/CMakeLists.txt
+++ b/bitbots_vision/CMakeLists.txt
@@ -50,6 +50,7 @@ add_custom_target(
 add_custom_command(
     TARGET extensions
     COMMAND python3 ${CMAKE_SOURCE_DIR}/../python_extensions/setup.py ARGS build install "--user"
+    COMMAND python2 ${CMAKE_SOURCE_DIR}/../python_extensions/setup.py ARGS build install "--user"
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/../python_extensions/
 )
 


### PR DESCRIPTION
Now the vision extensions are included in the CMake build process.
Closes issue #77 