### PR TITLE
Fix fcnn handler set rating

### DIFF
--- a/bitbots_vision/src/bitbots_vision/vision_modules/candidate.py
+++ b/bitbots_vision/src/bitbots_vision/vision_modules/candidate.py
@@ -1,4 +1,5 @@
 import abc
+import rospy
 
 
 class Candidate:
@@ -106,6 +107,15 @@ class Candidate:
         :return tuple: Returns the lowest point of the candidate. The point is horizontally centered inside the candidate.
         """
         return (self.get_center_x(), self.get_lower_right_y())
+
+    def set_rating(self, rating):
+        # type: (float) -> None
+        """
+        :param float rating: Rating to set.
+        """
+        if self._rating is not None:
+            rospy.logwarn('Candidate rating has already been set.', logger_name='Candidate')
+        self._rating = rating
 
     def get_rating(self):
         # type: () -> float

--- a/bitbots_vision/src/bitbots_vision/vision_modules/candidate.py
+++ b/bitbots_vision/src/bitbots_vision/vision_modules/candidate.py
@@ -115,6 +115,7 @@ class Candidate:
         """
         if self._rating is not None:
             rospy.logwarn('Candidate rating has already been set.', logger_name='Candidate')
+            return
         self._rating = rating
 
     def get_rating(self):

--- a/bitbots_vision/src/bitbots_vision/vision_modules/fcnn_handler.py
+++ b/bitbots_vision/src/bitbots_vision/vision_modules/fcnn_handler.py
@@ -78,13 +78,14 @@ class FcnnHandler(BallDetector):
                 # Get the fcnn heatmap
                 out = self.get_fcnn_output()
                 # Calculate the mean in the ROI in the heatmap
-                candidate.rating = np.mean(
+                rating = np.mean(
                     out[
                         candidate.get_upper_left_y():
                         candidate.get_upper_left_y() + candidate.get_height(),
                         candidate.get_upper_left_x():
                         candidate.get_upper_left_x() + candidate.get_width()]
                 ) / 255.0
+                candidate.set_rating(rating)
                 # Check if candidate is in rating threshold and size bounds
                 if self._inspect_candidate(candidate):
                     # Add candidate to list
@@ -99,7 +100,7 @@ class FcnnHandler(BallDetector):
         :return: a boolean if the candidate satisfies these conditions
         """
         # type: (Candidate) -> bool
-        return candidate.rating >= self._threshold \
+        return candidate.get_rating() >= self._threshold \
                and self._min_candidate_diameter \
                <= candidate.get_diameter() \
                <= self._max_candidate_diameter


### PR DESCRIPTION
Since #122, we have changed the name of the rating variable of a candidate. This PR fixes the problem of direct access of a not existing class variable.