### PR TITLE
white_balancer: add missing call to catkin_package

### DIFF
--- a/white_balancer/CMakeLists.txt
+++ b/white_balancer/CMakeLists.txt
@@ -25,6 +25,8 @@ generate_dynamic_reconfigure_options(
     cfg/white_balancer.cfg
 )
 
+catkin_package()
+
 include_directories(
   ${catkin_INCLUDE_DIRS}
 )

--- a/white_balancer/CMakeLists.txt
+++ b/white_balancer/CMakeLists.txt
@@ -34,6 +34,8 @@ include_directories(
 ## Declare a C++ executable
 add_executable(white_balancer src/white_balancer.cpp)
 
+add_dependencies(white_balancer ${PROJECT_NAME}_gencfg)
+
 ## Specify libraries to link a library or executable target against
 target_link_libraries(white_balancer
     ${catkin_LIBRARIES}

--- a/white_balancer/CMakeLists.txt
+++ b/white_balancer/CMakeLists.txt
@@ -1,10 +1,11 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(white_balancer)
 
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+endif()
 
-set(CMAKE_BUILD_TYPE Debug)
-
-FIND_PACKAGE (OpenCV REQUIRED)
+find_package(OpenCV REQUIRED)
 
 find_package(catkin REQUIRED COMPONENTS
   image_transport
@@ -16,9 +17,6 @@ find_package(catkin REQUIRED COMPONENTS
   message_generation
   cv_bridge
 )
-
-set (CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -Wall")
 
 # dynamic reconfigure
 generate_dynamic_reconfigure_options(


### PR DESCRIPTION
Without `catkin_package()` the dynamic reconfigure header cannot be found.
This pull request closes #130.