### PR TITLE
Bug fix in vision.py: Call right function

### DIFF
--- a/bitbots_vision/src/bitbots_vision/vision.py
+++ b/bitbots_vision/src/bitbots_vision/vision.py
@@ -95,7 +95,7 @@ class Vision:
         srv = Server(VisionConfig, self._dynamic_reconfigure_callback)
 
         # Add general params
-        ros_utils.set_check_generals(["caching"])
+        ros_utils.set_general_parameters(["caching"])
 
         # Run the vision main loop
         self._main_loop()


### PR DESCRIPTION
After the function rename, some error occured.

## Proposed changes
Rename function

## Necessary checks
- [x] Run linters
- [x] Run `catkin build`
- [ ] Write documentation
- [x] Test on your machine
- [x] Test on the robot

