### PR TITLE
Move mask normalization to color.py

### DIFF
--- a/bitbots_vision/package.xml
+++ b/bitbots_vision/package.xml
@@ -25,7 +25,7 @@
     The field color space itself can be dynamically adapted in real-time using the dynamic color space heuristic.
     Therefore the vision gets more resistant in natural light conditions.
   </description>
-  <version>1.1.1</version>
+  <version>1.1.2</version>
 
   <maintainer email="7vahl@informatik.uni-hamburg.de">Florian Vahl</maintainer>
   <maintainer email="info@bit-bots.de">Hamburg Bit-Bots</maintainer>

--- a/bitbots_vision/src/bitbots_vision/vision_modules/color.py
+++ b/bitbots_vision/src/bitbots_vision/vision_modules/color.py
@@ -90,6 +90,19 @@ class ColorDetector(object):
 
         return mask
 
+    def get_normalized_image_mask(self, optional_image=None):
+        # type: (np.array) -> np.array
+        """
+        Returns the image mask as described in `get_mask_image`, but the
+        range of the values is one or zero and the dtype is a float.
+
+        :param np.array optional_image: Optional input image
+        :return np.array: masked image
+        """
+        return np.floor_divide(
+            self.get_mask_image(optional_image),
+            255, dtype=np.int16)
+
     @abc.abstractmethod
     def _mask_image(self, image):
         # type: (np.array) -> np.array


### PR DESCRIPTION
Add the ability to query masks between 1 and 0 to the color detector. 

## Proposed changes
Add the ability to the color detector, by moving the code from the dynamic color space there,

## Related issues
Is was proposed by @JanGut  in Issue #137.
Closes #137.

## Necessary checks
- [x] Update package version
- [x] Run linters
- [x] Run `catkin build`
- [x] Write documentation
- [x] Test on your machine
- [ ] Test on the robot

