### PR TITLE
fix typo "visioparams.yaml" in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The camera drivers are not included in this package but can be auto launched.
 
 If you want the vision to run without starting a camera driver simply set the cli launch parameter `camera:=false`.
 Every image source, that publishes a `sensor_msgs/Image messages` message is also supported.
-The ROS topics and many other parameters are defined in the `visioparams.yaml` config file.
+The ROS topics and many other parameters are defined in the `visionparams.yaml` config file.
 All used parameters are also changeable during run-time using ros dynamic reconfigure.
 For simulation usage, different parameters can be defined in the ``simparam.yaml`` which overrides the normal params.
 The debug mode with special debug output can be activated using ``debug:=true``.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
fixed typo "visioparams.yaml" in readme
## Proposed changes
<!--- Describe your changes and why they are necessary. -->
change visioparams.yaml to visionparams.yaml

## Related issues
None

## Necessary checks
- [ ] Update package version
- [ ] Run linters
- [ ] Run `catkin build`
- [x] Write documentation
- [ ] Test on your machine
- [ ] Test on the robot

