### PR TITLE
remove old project-identifying files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,0 @@
-cmake_minimum_required(VERSION 3.7)
-project(bitbots_vision)
-
-set(CMAKE_CXX_STANDARD 11)
-
-add_executable(bitbots_vision ${SOURCE_FILES})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Proposed changes
This PR removes unneeded old project-identifying files.

The removed file are needed only if the containing folder is a CMake Project or python
package.
The main repo is neither therefore these files should be deleted.

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Necessary checks
- [ ] Update package version
- [ ] Run linters
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Test on your machine
- [ ] Test on the robot

