### PR TITLE
bitbots_vision: lines: Adds line detector offset for masks

### DIFF
--- a/bitbots_vision/cfg/Vision.cfg
+++ b/bitbots_vision/cfg/Vision.cfg
@@ -165,7 +165,7 @@ group_field_boundary_detector.add("field_boundary_detector_roi_increase", double
 group_field_boundary_detector.add("field_boundary_detector_green_threshold", int_t, 0, "Threshold of green in the area covered by the kernel", min=0, max=1000)
 group_field_boundary_detector.add("field_boundary_detector_head_tilt_threshold", int_t, 0, "Threshold for the dynamic search method, that describes the head angle at which we are switching between the iteration and the reversed search method.", min=0, max=90)
 
-group_line_detector.add("line_detector_field_boundary_offset", int_t, 0, "Threshold in which we are also searching for lines over the field boundary", min=0, max=200)
+group_line_detector.add("line_detector_field_boundary_offset", int_t, 0, "Threshold in which we are also searching for lines over the field boundary", min=-1000, max=1000)
 group_line_detector.add("line_detector_linepoints_range", int_t, 0, "Number of line points", min=0, max=20000)
 group_line_detector.add("line_detector_use_line_points", bool_t, 0, "Calculate and publish the line points", None)
 group_line_detector.add("line_detector_use_line_mask", bool_t, 0, "Calculate and publish the line mask", None)

--- a/bitbots_vision/src/bitbots_vision/vision_modules/field_boundary.py
+++ b/bitbots_vision/src/bitbots_vision/vision_modules/field_boundary.py
@@ -68,14 +68,38 @@ class FieldBoundaryDetector(object):
         self._convex_field_boundary_points = None
         self._mask = None
 
-    def get_mask(self):
+    def get_mask(self, offset=0):
         # type: () -> np.array
         """
+        :param offest: A vertical field boundary offset shift
         :return: np.array
         """
         # Compute mask (cached)
         self._compute_mask()
-        return self._mask
+        return self._shift_field_boundary_mask(self._mask, offset)
+
+    def _shift_field_boundary_mask(self, mask, offset):
+        shape = mask.shape
+
+        if offset == 0:
+            return mask
+
+        elif offset < 0:
+            # Shift mask downwards
+            offset = min(-offset, shape[0]-1)
+            frame = np.zeros(shape, dtype=np.uint8)
+            # Add mask with offset
+            frame[offset:shape[0]-1] = mask[0:shape[0]-1-offset]
+
+        elif offset > 0:
+            # Shift mask upwards
+            offset = min(offset, shape[0]-1)
+            frame = np.ones(shape, dtype=np.uint8)
+            frame = frame * 255
+            # Add mask with offset
+            frame[0:shape[0]-1-offset] = mask[offset:shape[0]-1]
+
+        return frame
 
     def _compute_mask(self):
         # type: () -> None

--- a/bitbots_vision/src/bitbots_vision/vision_modules/field_boundary.py
+++ b/bitbots_vision/src/bitbots_vision/vision_modules/field_boundary.py
@@ -71,7 +71,7 @@ class FieldBoundaryDetector(object):
     def get_mask(self, offset=0):
         # type: () -> np.array
         """
-        :param offest: A vertical field boundary offset shift
+        :param offset: A vertical field boundary offset shift
         :return: np.array
         """
         # Compute mask (cached)

--- a/bitbots_vision/src/bitbots_vision/vision_modules/lines.py
+++ b/bitbots_vision/src/bitbots_vision/vision_modules/lines.py
@@ -145,35 +145,13 @@ class LineDetector:
             # Invert and scale the field mask
             not_green_mask = np.ones_like(green_mask) - (np.floor_divide(green_mask, 255))
             # Get part under the field boundary as white mask
-            field_boundary_mask = self._field_boundary_detector.get_mask()
-            # Shift mask up- or downwards depending on field boundary offset
-            shifted_field_boundary_mask = self._shift_field_boundary_mask(field_boundary_mask, self._field_boundary_offset)
+            field_boundary_mask = self._field_boundary_detector.get_mask(offset=self._field_boundary_offset)
             # Get not green points under field boundary
-            possible_line_locations = cv2.bitwise_and(not_green_mask, not_green_mask, mask=shifted_field_boundary_mask)
+            possible_line_locations = cv2.bitwise_and(not_green_mask, not_green_mask, mask=field_boundary_mask)
             # Get white points that are not above the field boundary or in the green field
             self._white_mask = self._white_detector.mask_bitwise(possible_line_locations)
         return self._white_mask
 
-    def _shift_field_boundary_mask(self, mask, offset):
-        shape = mask.shape
-
-        if offset == 0:
-            return mask
-        elif offset < 0:
-            # Shift mask downwards
-            offset = min(-offset, shape[0]-1)
-            frame = np.zeros(shape, dtype=np.uint8)
-            # Add mask with offset
-            frame[offset:shape[0]-1] = mask[0:shape[0]-1-offset]
-        elif offset > 0:
-            # Shift mask upwards
-            offset = min(offset, shape[0]-1)
-            frame = np.ones(shape, dtype=np.uint8)
-            frame = frame * 255
-            # Add mask with offset
-            frame[0:shape[0]-1-offset] = mask[offset:shape[0]-1]
-
-        return frame
 
 def filter_points_with_candidates(linepoints, candidates):
     """

--- a/bitbots_vision/src/bitbots_vision/vision_modules/lines.py
+++ b/bitbots_vision/src/bitbots_vision/vision_modules/lines.py
@@ -146,12 +146,34 @@ class LineDetector:
             not_green_mask = np.ones_like(green_mask) - (np.floor_divide(green_mask, 255))
             # Get part under the field boundary as white mask
             field_boundary_mask = self._field_boundary_detector.get_mask()
+            # Shift mask up- or downwards depending on field boundary offset
+            shifted_field_boundary_mask = self._shift_field_boundary_mask(field_boundary_mask, self._field_boundary_offset)
             # Get not green points under field boundary
-            possible_line_locations = cv2.bitwise_and(not_green_mask, not_green_mask, mask=field_boundary_mask)
+            possible_line_locations = cv2.bitwise_and(not_green_mask, not_green_mask, mask=shifted_field_boundary_mask)
             # Get white points that are not above the field boundary or in the green field
             self._white_mask = self._white_detector.mask_bitwise(possible_line_locations)
         return self._white_mask
 
+    def _shift_field_boundary_mask(self, mask, offset):
+        shape = mask.shape
+
+        if offset == 0:
+            return mask
+        elif offset < 0:
+            # Shift mask downwards
+            offset = min(-offset, shape[0]-1)
+            frame = np.zeros(shape, dtype=np.uint8)
+            # Add mask with offset
+            frame[offset:shape[0]-1] = mask[0:shape[0]-1-offset]
+        elif offset > 0:
+            # Shift mask upwards
+            offset = min(offset, shape[0]-1)
+            frame = np.ones(shape, dtype=np.uint8)
+            frame = frame * 255
+            # Add mask with offset
+            frame[0:shape[0]-1-offset] = mask[offset:shape[0]-1]
+
+        return frame
 
 def filter_points_with_candidates(linepoints, candidates):
     """


### PR DESCRIPTION
Adds line detector offset for masks and now also supports negative offset.

## Proposed changes
The offset parameter was not yet implemented for line masks.
This is also needed for the RoboCup project.

## Related issues
None

## Necessary checks
- [ ] Update package version
- [X] Run linters
- [X] Run `catkin build`
- [ ] ~~Write documentation~~
- [X] Test on your machine
- [ ] Test on the robot
