### PR TITLE
Field boundary detector: Swap height and width of the kernel

### DIFF
--- a/bitbots_vision/package.xml
+++ b/bitbots_vision/package.xml
@@ -25,7 +25,7 @@
     The field color space itself can be dynamically adapted in real-time using the dynamic color space heuristic.
     Therefore the vision gets more resistant in natural light conditions.
   </description>
-  <version>1.1.2</version>
+  <version>1.1.3</version>
 
   <maintainer email="7vahl@informatik.uni-hamburg.de">Florian Vahl</maintainer>
   <maintainer email="info@bit-bots.de">Hamburg Bit-Bots</maintainer>

--- a/bitbots_vision/src/bitbots_vision/vision_modules/field_boundary.py
+++ b/bitbots_vision/src/bitbots_vision/vision_modules/field_boundary.py
@@ -665,7 +665,7 @@ class DownsamplingReversedFieldBoundaryAlgorithm(FieldBoundaryAlgorithm):
         # Scale the image down
         subsampled_mask = cv2.resize(field_mask,(x_steps,y_steps), interpolation=cv2.INTER_AREA)
         # Define the blur kernel
-        kernel = (2 * (roi_height // 2) + 1, 2 * (roi_width // 2) + 1)
+        kernel = (2 * (roi_width // 2) + 1, 2 * (roi_height // 2) + 1)
         # Blur the downscaled image to fill holes in the field mask
         subsampled_mask = cv2.GaussianBlur(subsampled_mask, kernel, 0)
 


### PR DESCRIPTION
The kernel aspect ratio was swaped. This pull request fixes it.

## Proposed changes
I swaped them.

## Related issues
#181 
## Necessary checks
- [x] Update package version
- [x] Run linters
- [x] Run `catkin build`
- [x] Write documentation
- [x] Test on your machine
- [ ] Test on the robot

