### PR TITLE
Add dynamic reconfigure for yolo params

### DIFF
--- a/bitbots_vision/cfg/Vision.cfg
+++ b/bitbots_vision/cfg/Vision.cfg
@@ -106,7 +106,7 @@ group_ROS.add("ROS_dynamic_color_space_field_mask_image_msg_topic", str_t, 0, "R
 group_neural_networks.add("neural_network_type", str_t, 0, "The neural network type that should be used (fcnn, yolo_opencv, yolo_darknet or dummy)", "fcnn", edit_method=neural_network_type_enum)
 
 group_yolo.add("yolo_model_path", str_t, 0, "Name of the yolo model", dummy_list[0], edit_method=yolo_paths_enum)
-group_yolo.add("yolo_nms_threshold", double_t, 0, "Non maximum suppresion threshold", min=0.0, max=1.0)
+group_yolo.add("yolo_nms_threshold", double_t, 0, "Yolo: Non maximum suppression threshold", min=0.0, max=1.0)
 group_yolo.add("yolo_confidence_threshold", double_t, 0, "Yolo: confidence threshold", min=0.0, max=1.0)
 
 group_fcnn.add("fcnn_model_path", str_t, 0, "Name of the ball fcnn model", dummy_list[0], edit_method=fcnn_paths_enum)

--- a/bitbots_vision/cfg/Vision.cfg
+++ b/bitbots_vision/cfg/Vision.cfg
@@ -106,6 +106,8 @@ group_ROS.add("ROS_dynamic_color_space_field_mask_image_msg_topic", str_t, 0, "R
 group_neural_networks.add("neural_network_type", str_t, 0, "The neural network type that should be used (fcnn, yolo_opencv, yolo_darknet or dummy)", "fcnn", edit_method=neural_network_type_enum)
 
 group_yolo.add("yolo_model_path", str_t, 0, "Name of the yolo model", dummy_list[0], edit_method=yolo_paths_enum)
+group_yolo.add("yolo_nms_threshold", double_t, 0, "Non maximum suppresion threshold", min=0.0, max=1.0)
+group_yolo.add("yolo_confidence_threshold", double_t, 0, "Yolo confidence threshold", min=0.0, max=1.0)
 
 group_fcnn.add("fcnn_model_path", str_t, 0, "Name of the ball fcnn model", dummy_list[0], edit_method=fcnn_paths_enum)
 group_fcnn.add("ball_fcnn_threshold", double_t, 0, "Minimal activation for a pixel in the fcnn heatmap to be considered", min=0.0, max=1.0)

--- a/bitbots_vision/cfg/Vision.cfg
+++ b/bitbots_vision/cfg/Vision.cfg
@@ -107,7 +107,7 @@ group_neural_networks.add("neural_network_type", str_t, 0, "The neural network t
 
 group_yolo.add("yolo_model_path", str_t, 0, "Name of the yolo model", dummy_list[0], edit_method=yolo_paths_enum)
 group_yolo.add("yolo_nms_threshold", double_t, 0, "Non maximum suppresion threshold", min=0.0, max=1.0)
-group_yolo.add("yolo_confidence_threshold", double_t, 0, "Yolo confidence threshold", min=0.0, max=1.0)
+group_yolo.add("yolo_confidence_threshold", double_t, 0, "Yolo: confidence threshold", min=0.0, max=1.0)
 
 group_fcnn.add("fcnn_model_path", str_t, 0, "Name of the ball fcnn model", dummy_list[0], edit_method=fcnn_paths_enum)
 group_fcnn.add("ball_fcnn_threshold", double_t, 0, "Minimal activation for a pixel in the fcnn heatmap to be considered", min=0.0, max=1.0)

--- a/bitbots_vision/config/visionparams.yaml
+++ b/bitbots_vision/config/visionparams.yaml
@@ -24,7 +24,7 @@ ROS_dynamic_color_space_field_mask_image_msg_topic: 'dynamic_field_mask'  # ROS 
 fcnn_model_path: '2019_06_timon_basler'  # Name of the ball fcnn model
 yolo_model_path: '2019_07_03_jonas_yolo'  # Name of the yolo model
 yolo_nms_threshold: 0.4  # Non maximum suppression threshold
-yolo_confidence_threshold: 0.5   # Yolo confidence threshold
+yolo_confidence_threshold: 0.5  # Yolo: confidence threshold
 
 ball_fcnn_threshold: .6  # Minimal activation for a pixel in the fcnn heatmap to be considered
 ball_fcnn_expand_stepsize: 4  # Expand stepsize for the ball fcnn clustering

--- a/bitbots_vision/config/visionparams.yaml
+++ b/bitbots_vision/config/visionparams.yaml
@@ -23,6 +23,9 @@ ROS_dynamic_color_space_field_mask_image_msg_topic: 'dynamic_field_mask'  # ROS 
 
 fcnn_model_path: '2019_06_timon_basler'  # Name of the ball fcnn model
 yolo_model_path: '2019_07_03_jonas_yolo'  # Name of the yolo model
+yolo_nms_threshold: 0.4   # Non maximum suppresion threshold
+yolo_confidence_threshold: 0.5   # Yolo confidence threshold
+
 ball_fcnn_threshold: .6  # Minimal activation for a pixel in the fcnn heatmap to be considered
 ball_fcnn_expand_stepsize: 4  # Expand stepsize for the ball fcnn clustering
 ball_fcnn_pointcloud_stepsize: 10  # Pointcloud stepsize for the ball fcnn clustering

--- a/bitbots_vision/config/visionparams.yaml
+++ b/bitbots_vision/config/visionparams.yaml
@@ -23,7 +23,7 @@ ROS_dynamic_color_space_field_mask_image_msg_topic: 'dynamic_field_mask'  # ROS 
 
 fcnn_model_path: '2019_06_timon_basler'  # Name of the ball fcnn model
 yolo_model_path: '2019_07_03_jonas_yolo'  # Name of the yolo model
-yolo_nms_threshold: 0.4   # Non maximum suppresion threshold
+yolo_nms_threshold: 0.4  # Non maximum suppression threshold
 yolo_confidence_threshold: 0.5   # Yolo confidence threshold
 
 ball_fcnn_threshold: .6  # Minimal activation for a pixel in the fcnn heatmap to be considered
@@ -110,4 +110,3 @@ ball_fcnn_publish_debug_img: false  # Publish the fcnn heatmap image for debug p
 vision_publish_HSV_mask_image: false  # Publish all three HSV color detector mask image messages for debug purposes
 vision_publish_field_mask_image: false  # Publish field mask image message for debug purposes
 caching: true  # Used to deactivate caching for profiling reasons
-

--- a/bitbots_vision/src/bitbots_vision/vision.py
+++ b/bitbots_vision/src/bitbots_vision/vision.py
@@ -314,6 +314,7 @@ class Vision:
 
         # Check if the yolo ball/goalpost detector is activated. No matter which implementation is used.
         if config['neural_network_type'] in ['yolo_opencv', 'yolo_darknet']:
+            # Check if a reload of the handler is needed
             if ros_utils.config_param_change(self._config, config, ['yolo_model_path', 'neural_network_type']):
                 # Build absolute model path
                 yolo_model_path = os.path.join(self._package_path, 'models', config['yolo_model_path'])
@@ -332,6 +333,9 @@ class Vision:
                     self._ball_detector = yolo_handler.YoloBallDetector(config, self._yolo)
                     self._goalpost_detector = yolo_handler.YoloGoalpostDetector(config, self._yolo)
                     rospy.loginfo(config['neural_network_type'] + " vision is running now", logger_name="vision_yolo")
+            # For other changes only modify the config
+            elif ros_utils.config_param_change(self._config, config, r'yolo_'):
+                self._yolo.set_config(config)
 
         self._register_or_update_all_subscribers(config)
 

--- a/bitbots_vision/src/bitbots_vision/vision_modules/ros_utils.py
+++ b/bitbots_vision/src/bitbots_vision/vision_modules/ros_utils.py
@@ -475,7 +475,7 @@ def set_general_parameters(params):
     """
     general_parameters.extend(params)
 
-def config_param_change(old_config, new_config, params, check_generals=True):
+def config_param_change(old_config, new_config, params_expressions, check_generals=True):
     # type: (dict, dict, [str]) -> bool
     """
     Checks whether some of the specified config params have changed.
@@ -487,14 +487,21 @@ def config_param_change(old_config, new_config, params, check_generals=True):
     :return bool: True if parameter has changed
     """
     # Make regex instead of list possible
-    if not isinstance(params, list):
+    if not isinstance(params_expressions, list):
+        params_expressions = [params_expressions]
+
+    # Matching parameters
+    params = []
+    # Iterate over expressions
+    for param in params_expressions:
         # Build regex
-        regex = re.compile(params)
+        regex = re.compile(param)
         # Filter parameter names by regex
-        params = list(filter(regex.search, list(new_config.keys())))
-        # Check if parameters matching this regex exist
-        if len(params) == 0:
-            raise KeyError('Regex \'{}\' has no matches in dict.'.format(params))
+        params.extend(list(filter(regex.search, list(new_config.keys()))))
+
+    # Check if parameters matching this regex exist
+    if len(params) == 0:
+        raise KeyError('Regex \'{}\' has no matches in dict.'.format(params))
 
     # Add general params to parameters
     if check_generals:

--- a/bitbots_vision/src/bitbots_vision/vision_modules/yolo_handler.py
+++ b/bitbots_vision/src/bitbots_vision/vision_modules/yolo_handler.py
@@ -130,17 +130,18 @@ class YoloHandlerDarknet(YoloHandler):
                 class_id = out[0]
                 # Get confidence
                 confidence = out[1]
-                # Get candidate position and size
-                x, y, w, h = out[2]
-                x = x - int(w // 2)
-                y = y - int(h // 2)
-                # Create candidate
-                c = Candidate(int(x), int(y), int(w), int(h), confidence)
-                # Append candidate to the right list depending on the class
-                if class_id == b"ball":
-                    self._ball_candidates.append(c)
-                if class_id == b"goalpost":
-                    self._goalpost_candidates.append(c)
+                if confidence > self._confidence_threshold:
+                    # Get candidate position and size
+                    x, y, w, h = out[2]
+                    x = x - int(w // 2)
+                    y = y - int(h // 2)
+                    # Create candidate
+                    c = Candidate(int(x), int(y), int(w), int(h), confidence)
+                    # Append candidate to the right list depending on the class
+                    if class_id == b"ball":
+                        self._ball_candidates.append(c)
+                    if class_id == b"goalpost":
+                        self._goalpost_candidates.append(c)
 
 class YoloHandlerOpenCV(YoloHandler):
     """

--- a/bitbots_vision/src/bitbots_vision/vision_modules/yolo_handler.py
+++ b/bitbots_vision/src/bitbots_vision/vision_modules/yolo_handler.py
@@ -194,20 +194,21 @@ class YoloHandlerOpenCV(YoloHandler):
                     class_id = np.argmax(scores)
                     # Get confidence from score
                     confidence = scores[class_id]
-                    # Static threshold
-                    # Get center point of the candidate
-                    center_x = int(detection[0] * self._width)
-                    center_y = int(detection[1] * self._height)
-                    # Get the heigh/width
-                    w = int(detection[2] * self._width)
-                    h = int(detection[3] * self._height)
-                    # Calc the upper left point
-                    x = center_x - w / 2
-                    y = center_y - h / 2
-                    # Append result
-                    class_ids.append(class_id)
-                    confidences.append(float(confidence))
-                    boxes.append([x, y, w, h])
+                    # First threshold to decrease candidate count and inscrease performance
+                    if confidence > self._confidence_threshold:
+                        # Get center point of the candidate
+                        center_x = int(detection[0] * self._width)
+                        center_y = int(detection[1] * self._height)
+                        # Get the heigh/width
+                        w = int(detection[2] * self._width)
+                        h = int(detection[3] * self._height)
+                        # Calc the upper left point
+                        x = center_x - w / 2
+                        y = center_y - h / 2
+                        # Append result
+                        class_ids.append(class_id)
+                        confidences.append(float(confidence))
+                        boxes.append([x, y, w, h])
 
             # Merge boxes
             indices = cv2.dnn.NMSBoxes(boxes, confidences, self._confidence_threshold, self._nms_threshold)


### PR DESCRIPTION
Add dynamic reconfigure for yolo parameters.

## Proposed changes
- Add parameters to `.cfg` and `.yaml`.
- Add config dict handling to the yolo handler
- Add config param change checks to the `vision.py`

## Related issues
Issue #151 

## Note!
This pull request should wait for #170 because the changes are in conflict with each other and one of them needs to be merged first, afterwards the other one needs some adjustments. If this one is reviewed faster it could also be merged first.

## Necessary checks
- [ ] Update package version
- [x] Run linters
- [x] Run `catkin build`
- [x] Write documentation
- [x] Test on your machine
- [ ] Test on the robot

