### PR TITLE
Launch: Add lauch script for rosbag record

### DIFF
--- a/bitbots_vision/launch/record_bag.launch
+++ b/bitbots_vision/launch/record_bag.launch
@@ -1,0 +1,8 @@
+<launch>
+    <arg name="camera" default="true" doc="true: launches an image provider to get images from a camera" />
+
+    <include if="$(arg camera)" file="$(find bitbots_bringup)/launch/basler_camera.launch" />
+
+    <node pkg="rosbag" type="record" name="rosbag_record_cam"
+        args="-o /tmp/tmpbag.bag image_raw camera_info" />
+</launch>


### PR DESCRIPTION
This PR adds a launch script to record camera rosbags.

## Proposed changes
- Add launch script file

## Related issues
- #113 

## Necessary checks
- [ ] Update package version
- [ ] ~Run linters~
- [ ] ~Run `catkin build`~
- [ ] ~Write documentation~
- [x] Test on your machine
- [x] Test on the robot

