### PR TITLE
Fix transfer image read flag

### DIFF
--- a/bitbots_vision/package.xml
+++ b/bitbots_vision/package.xml
@@ -43,7 +43,7 @@
 
   </description>
 
-  <version>1.1.10</version>
+  <version>1.1.11</version>
 
   <maintainer email="7vahl@informatik.uni-hamburg.de">Florian Vahl</maintainer>
   <maintainer email="7gutsche@informatik.uni-hamburg.de">Jan Gutsche</maintainer>

--- a/bitbots_vision/src/bitbots_vision/vision.py
+++ b/bitbots_vision/src/bitbots_vision/vision.py
@@ -122,7 +122,9 @@ class Vision:
             # Check if a new image is avalabile
             elif self._transfer_image_msg is not None:
                 # Copy image from shared memory
+                self._transfer_image_msg_read_flag = True
                 image_msg = deepcopy(self._transfer_image_msg)
+                self._transfer_image_msg_read_flag = False
                 self._transfer_image_msg = None
                 # Run the vision pipeline
                 self._handle_image(image_msg)


### PR DESCRIPTION
## Proposed changes
Changes the `_transfer_image_msg_read_flag` as expected.

## Related issues
Closes #211.
In future, we should use `threading.Lock` instead: #212

## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
  ~Write documentation~
- [x] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

