### PR TITLE
bitbots_vision: Limit dyn colorspace rate

### DIFF
--- a/bitbots_vision/cfg/Vision.cfg
+++ b/bitbots_vision/cfg/Vision.cfg
@@ -140,6 +140,7 @@ group_hsv_field_color_detector.add("field_color_detector_upper_values_s", int_t,
 group_hsv_field_color_detector.add("field_color_detector_upper_values_v", int_t, 0, "Upper bound for the field color detector value/brightness", min=0, max=255)
 
 group_dynamic_color_space.add("dynamic_color_space_active", bool_t, 0, "Turn dynamic color space ON or OFF", None)
+group_dynamic_color_space.add("dynamic_color_space_max_fps", double_t, 0, "Maximum FPS of the dynamic color space node", min=0, max=100)
 group_dynamic_color_space.add("dynamic_color_space_queue_max_size", int_t, 0, "Maximum size of queue that holds the latest added colors", min=1, max=100)
 group_dynamic_color_space.add("dynamic_color_space_threshold", double_t, 0, "Necessary amount of previously detected color inside the kernel in percentage", min=0.0, max=1.0)
 group_dynamic_color_space.add("dynamic_color_space_kernel_radius", int_t, 0, "Radius surrounding the center-element of kernel-matrix, defines relevant surrounding of pixel", min=1, max=100)

--- a/bitbots_vision/config/visionparams.yaml
+++ b/bitbots_vision/config/visionparams.yaml
@@ -48,6 +48,7 @@ field_color_detector_path: 'basler_f031.pickle'  # Color space for the field col
 field_color_detector_use_hsv: false
 
 dynamic_color_space_active: true  # Turn dynamic color space ON or OFF
+dynamic_color_space_max_fps: 1.0  # Maximum FPS of the dynamic color space node
 dynamic_color_space_queue_max_size: 20  # Maximum size of queue that holds the latest added colors
 dynamic_color_space_threshold: 0.55  # Necessary amount of previously detected color inside the kernel in percentage
 dynamic_color_space_kernel_radius: 1  # Radius surrounding the center-element of kernel-matrix, defines relevant surrounding of pixel

--- a/bitbots_vision/package.xml
+++ b/bitbots_vision/package.xml
@@ -8,7 +8,7 @@
     For further information and getting started, see the documentation of this package at our website: http://doku.bit-bots.de/package/bitbots_vision/latest/index.html
   </description>
 
-  <version>1.1.20</version>
+  <version>1.2.0</version>
 
   <maintainer email="7vahl@informatik.uni-hamburg.de">Florian Vahl</maintainer>
   <maintainer email="7gutsche@informatik.uni-hamburg.de">Jan Gutsche</maintainer>

--- a/bitbots_vision/src/bitbots_vision/dynamic_color_space.py
+++ b/bitbots_vision/src/bitbots_vision/dynamic_color_space.py
@@ -44,6 +44,8 @@ class DynamicColorSpace:
 
         # Init params
         self._vision_config = {}
+        self._max_fps = None
+        self._last_time = 0  # Time since we have received the last image
 
         # Publisher placeholder
         self._pub_color_space = None
@@ -83,6 +85,10 @@ class DynamicColorSpace:
                 rospy.loginfo('Dynamic color space turned ON.', logger_name="dynamic_color_space")
             else:
                 rospy.logwarn('Dynamic color space turned OFF.', logger_name="dynamic_color_space")
+
+        if ros_utils.config_param_change(self._vision_config, vision_config, 'dynamic_color_space_max_fps'):
+            self._max_fps = vision_config['dynamic_color_space_max_fps']
+            self._last_time = rospy.get_rostime()
 
         # Set publisher of ColorSpace-messages
         self._pub_color_space = ros_utils.create_or_update_publisher(self._vision_config, vision_config, self._pub_color_space, 'ROS_dynamic_color_space_msg_topic', ColorSpace)
@@ -148,6 +154,12 @@ class DynamicColorSpace:
             rospy.logwarn(f"Vision: Dropped incoming Image-message, because its too old! ({image_age.to_sec()} sec)",
                             logger_name="dynamic_color_space")
             return
+
+        # Skip images to constrain node to maximum FPS
+        time = rospy.get_rostime()
+        if self._max_fps == 0.0 or (time - self._last_time).to_sec() < (1 / self._max_fps):
+            return
+        self._last_time = time
 
         self._handle_image(image_msg)
 

--- a/bitbots_vision/src/bitbots_vision/dynamic_color_space.py
+++ b/bitbots_vision/src/bitbots_vision/dynamic_color_space.py
@@ -45,7 +45,7 @@ class DynamicColorSpace:
         # Init params
         self._vision_config = {}
         self._max_fps = None
-        self._last_time = 0  # Time since we have received the last image
+        self._last_time = rospy.get_rostime()  # Time since we have received the last image
 
         # Publisher placeholder
         self._pub_color_space = None


### PR DESCRIPTION
## Proposed changes
This PR ratelimits the dynamic color space node using a new `dynamic_color_space_max_fps` parameter.

## Related issues
Closes #246.

## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
- [x] Write documentation
~- [ ] Create issues for future work~
- [x] Test on your machine
~- [ ] Test on the robot~
- [x] Put the PR on our Project board

