### PR TITLE
make tensorflow requirement optional

### DIFF
--- a/bitbots_vision/package.xml
+++ b/bitbots_vision/package.xml
@@ -8,7 +8,7 @@
     For further information and getting started, see the documentation of this package at our website: http://doku.bit-bots.de/package/bitbots_vision/latest/index.html
   </description>
 
-  <version>1.3.2</version>
+  <version>1.3.3</version>
 
   <maintainer email="7vahl@informatik.uni-hamburg.de">Florian Vahl</maintainer>
   <maintainer email="7gutsche@informatik.uni-hamburg.de">Jan Gutsche</maintainer>

--- a/bitbots_vision/src/bitbots_vision/vision_modules/live_fcnn_03.py
+++ b/bitbots_vision/src/bitbots_vision/vision_modules/live_fcnn_03.py
@@ -1,6 +1,9 @@
 import os
-import tensorflow as tf
 import rospy
+try:
+    import tensorflow as tf
+except ImportError:
+    rospy.logerr('No tensorflow installed, cannot use fcnn model')
 
 
 class FCNN03:


### PR DESCRIPTION
## Proposed changes
Darknet and OpenVino are currently optional and errors are raised at import time. This also makes tensorflow optional.

## Necessary checks
- [x] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

