### PR TITLE
Line mask remove ball and goal post candidates

### DIFF
--- a/bitbots_vision/cfg/Vision.cfg
+++ b/bitbots_vision/cfg/Vision.cfg
@@ -183,6 +183,7 @@ group_line_detector.add("line_detector_field_boundary_offset", int_t, 0, "Thresh
 group_line_detector.add("line_detector_linepoints_range", int_t, 0, "Number of line points", min=0, max=20000)
 group_line_detector.add("line_detector_use_line_points", bool_t, 0, "Calculate and publish the line points", None)
 group_line_detector.add("line_detector_use_line_mask", bool_t, 0, "Calculate and publish the line mask", None)
+group_line_detector.add("line_detector_object_remove_grow", double_t, 0, "Makes objects like the ball larger before removing them from the mask", min=0, max=10)
 
 group_obstacle_detector.add("obstacle_active", bool_t, 0, "Enables the obstacle detection", None)
 group_obstacle_detector.add("obstacle_finder_method", str_t, 0, "Method for the obstacle finder (distance, convex or step)", "distance", edit_method=obstacle_detector_enum)

--- a/bitbots_vision/config/visionparams.yaml
+++ b/bitbots_vision/config/visionparams.yaml
@@ -98,6 +98,7 @@ line_detector_field_boundary_offset: 0  # Threshold in which we are also searchi
 line_detector_use_line_points: false  # Calculate and publish the line points
 line_detector_use_line_mask: false  # Calculate and publish the line mask
 line_detector_linepoints_range: 10000  # Number of line points
+line_detector_object_remove_grow: 1.3   # Makes objects like the ball larger before removing them from the mask
 
 obstacle_active: false  # Enables the obstacle detection
 obstacle_finder_method: 'convex'  # Method for the obstacle finder (distance, convex or step)

--- a/bitbots_vision/src/bitbots_vision/vision.py
+++ b/bitbots_vision/src/bitbots_vision/vision.py
@@ -576,8 +576,10 @@ class Vision:
             self._pub_lines.publish(line_msg)
 
         if self._use_line_mask:
+            # Define detections (Balls, Goal Posts) that are excluded from the line mask
+            excluded_objects = top_balls + goal_posts
             # Get line pixel mask
-            line_mask = self._line_detector.get_line_mask()
+            line_mask = self._line_detector.get_line_mask_without_other_objects(excluded_objects)
             # Create line mask message
             line_mask_message = ros_utils.build_image_msg(image_msg.header, line_mask, '8UC1')
             # Publish line mask
@@ -736,7 +738,9 @@ class Vision:
         # Draw line mask
         if self._use_line_mask:
             self._debug_image_creator.draw_mask(
-                self._line_detector.get_line_mask(),
+                self._line_detector.get_line_mask_without_other_objects(
+                    []
+                ),
                 color=(255, 0, 0),
                 opacity=0.8
             )

--- a/bitbots_vision/src/bitbots_vision/vision_modules/candidate.py
+++ b/bitbots_vision/src/bitbots_vision/vision_modules/candidate.py
@@ -195,7 +195,7 @@ class Candidate:
     def rating_threshold(candidatelist, threshold):
         """
         Returns list of all candidates with rating above given threshold.
-        
+
         :param [Candidate] candidatelist: List of candidates to filter
         :param float threshold: Filter threshold
         :return [Candidate]: Filtered list of candidates
@@ -205,7 +205,7 @@ class Candidate:
     def __str__(self):
         """
         Returns string representation of candidate.
-        
+
         :return str: String representation of candidate
         """
         return f"x1,y1: {self.get_upper_left_x()},{self.get_upper_left_y()} | width,height: {self.get_width()},{self.get_height()} | rating: {self._rating}"

--- a/bitbots_vision/src/bitbots_vision/vision_modules/candidate.py
+++ b/bitbots_vision/src/bitbots_vision/vision_modules/candidate.py
@@ -159,6 +159,14 @@ class Candidate:
                 <= point[1]
                 <= self.get_upper_left_y() + self.get_height())
 
+    def subtract_from_mask(self, mask, grow=1):
+        width = int(self.get_width() * grow * 0.5)
+        height = int(self.get_height() * grow * 0.5)
+        mask[
+            max(self.get_center_y() - height, 0) : min(self.get_center_y() + height, mask.shape[0]),
+            max(self.get_center_x() - width, 0): min(self.get_center_x() + width, mask.shape[1])] = 0
+        return mask
+
     @staticmethod
     def sort_candidates(candidatelist):
         """

--- a/bitbots_vision/src/bitbots_vision/vision_modules/candidate.py
+++ b/bitbots_vision/src/bitbots_vision/vision_modules/candidate.py
@@ -159,12 +159,20 @@ class Candidate:
                 <= point[1]
                 <= self.get_upper_left_y() + self.get_height())
 
-    def subtract_from_mask(self, mask, grow=1):
+    def set_in_mask(self, mask, value=0, grow=1):
+        """
+        Sets the bounding box of this candidate in the given mask to the given value.
+
+        :param mask: Binary mask with the shape of the input image
+        :param value: The value of the bounding box region
+        :param grow: A scalar which defines how much arround the box is also removed
+        :returns mask: The input mask without this candidate
+        """
         width = int(self.get_width() * grow * 0.5)
         height = int(self.get_height() * grow * 0.5)
         mask[
             max(self.get_center_y() - height, 0) : min(self.get_center_y() + height, mask.shape[0]),
-            max(self.get_center_x() - width, 0): min(self.get_center_x() + width, mask.shape[1])] = 0
+            max(self.get_center_x() - width, 0): min(self.get_center_x() + width, mask.shape[1])] = value
         return mask
 
     @staticmethod

--- a/bitbots_vision/src/bitbots_vision/vision_modules/debug.py
+++ b/bitbots_vision/src/bitbots_vision/vision_modules/debug.py
@@ -11,11 +11,12 @@ class DebugImage:
     the goalposts (white bounding boxes) and
     different obstacles (black: unknown, red: red robot, blue: blue robot).
     """
-    def __init__(self):
+    def __init__(self, active=True):
         """
         Initialization of :class:`.DebugImage`.
         """
         self._debug_image = None
+        self.active = active
 
     def set_image(self, image):
         """
@@ -33,6 +34,7 @@ class DebugImage:
         :param color: color of the line
         :param thickness: thickness of the line
         """
+        if not self.active: return
         for i in range(len(field_boundary_points) - 1):
             cv2.line(self._debug_image,
                      field_boundary_points[i],
@@ -46,6 +48,7 @@ class DebugImage:
         :param color: color of the circle to draw
         :param thickness: thickness of the outline
         """
+        if not self.active: return
         for candidate in ball_candidates:
             if candidate:
                 cv2.circle(self._debug_image,
@@ -62,6 +65,7 @@ class DebugImage:
         :param color: color of the outline
         :param thickness: thickness of the outline
         """
+        if not self.active: return
         for candidate in obstacle_candidates:
             if candidate:
                 cv2.rectangle(self._debug_image,
@@ -79,6 +83,7 @@ class DebugImage:
         :param thickness: thickness of the outline
         :param rad: radius of the point
         """
+        if not self.active: return
         for point in points:
             cv2.circle(self._debug_image, point, rad, color, thickness=thickness)
 
@@ -90,6 +95,7 @@ class DebugImage:
         :param color: color of the line
         :param thickness: thickness of the line
         """
+        if not self.active: return
         for segment in segments:
             cv2.line(self._debug_image,
                      (segment[0], segment[1]),
@@ -97,6 +103,7 @@ class DebugImage:
                      color, thickness=2)
 
     def draw_mask(self, mask, color, opacity=0.5):
+        if not self.active: return
         # Make a colored image
         colored_image = np.zeros_like(self._debug_image)
         colored_image[:, :] = tuple(np.multiply(color, opacity).astype(np.uint8))

--- a/bitbots_vision/src/bitbots_vision/vision_modules/lines.py
+++ b/bitbots_vision/src/bitbots_vision/vision_modules/lines.py
@@ -162,6 +162,12 @@ class LineDetector:
         return self._white_mask
 
     def get_line_mask_without_other_objects(self, candidate_list):
+        """
+        Generates a white mask that not contains pixels in the green field, above the field boundary or in the specified candidates.
+
+        :param candidate_list: List ob candidate bounding boxes that are subtracted from the final mask
+        :return: Mask
+        """
         mask = self.get_line_mask().copy()
         for candidate in candidate_list:
             mask = candidate.subtract_from_mask(mask)

--- a/bitbots_vision/src/bitbots_vision/vision_modules/lines.py
+++ b/bitbots_vision/src/bitbots_vision/vision_modules/lines.py
@@ -29,6 +29,7 @@ class LineDetector:
         self._linepoints_range = config['line_detector_linepoints_range']
         self._use_line_points = config['line_detector_use_line_points']
         self._use_line_mask = config['line_detector_use_line_mask']
+        self._object_grow = config['line_detector_object_remove_grow']
 
         # Set if values should be cached
         self._caching = config['caching']
@@ -170,7 +171,7 @@ class LineDetector:
         """
         mask = self.get_line_mask().copy()
         for candidate in candidate_list:
-            mask = candidate.set_in_mask(mask, 0)
+            mask = candidate.set_in_mask(mask, 0, self._object_grow)
         return mask
 
 

--- a/bitbots_vision/src/bitbots_vision/vision_modules/lines.py
+++ b/bitbots_vision/src/bitbots_vision/vision_modules/lines.py
@@ -161,6 +161,12 @@ class LineDetector:
             self._white_mask = cv2.medianBlur(white_mask, 3)
         return self._white_mask
 
+    def get_line_mask_without_other_objects(self, candidate_list):
+        mask = self.get_line_mask().copy()
+        for candidate in candidate_list:
+            mask = candidate.subtract_from_mask(mask)
+        return mask
+
 
 def filter_points_with_candidates(linepoints, candidates):
     """

--- a/bitbots_vision/src/bitbots_vision/vision_modules/lines.py
+++ b/bitbots_vision/src/bitbots_vision/vision_modules/lines.py
@@ -170,7 +170,7 @@ class LineDetector:
         """
         mask = self.get_line_mask().copy()
         for candidate in candidate_list:
-            mask = candidate.subtract_from_mask(mask)
+            mask = candidate.set_in_mask(mask, 0)
         return mask
 
 


### PR DESCRIPTION
## Proposed changes
Removes ball and goal post candidates from the line mask.
It also moves the debug drawer in the vision and cleans stuff up.


Closes #265 
