### PR TITLE
Use rospy rate again and increase rate of vision

### DIFF
--- a/bitbots_vision/src/bitbots_vision/vision.py
+++ b/bitbots_vision/src/bitbots_vision/vision.py
@@ -17,7 +17,6 @@ from bitbots_vision.vision_modules import lines, field_boundary, color, debug, \
     obstacle, yolo_handler, ros_utils, candidate
 from bitbots_vision.cfg import VisionConfig
 from bitbots_msgs.msg import Config, ColorLookupTable
-from bitbots_ros_patches.rate import Rate
 try:
     from profilehooks import profile, timecall # Profilehooks profiles certain functions in you add the @profile or @timecall decorator.
 except ImportError:
@@ -104,7 +103,7 @@ class Vision:
         ros_utils.set_general_parameters(["caching"])
 
         # Define the rate of a sleep timer
-        self._rate = Rate(100)
+        self._rate = rospy.Rate(130)
 
         # Run the vision main loop
         self._main_loop()


### PR DESCRIPTION
## Proposed changes
- Use rospy.Rate again
- Increase vision frequency to 130 Hz (double of the camera rate) instead of 100 Hz

Increasing the rate should not be any problem, as the vision does only a few very lightweight checks, if no new image is available.
However, by increasing the rate, we stop wasting 62.5% of our available time to handle an image in the worst case.

## Related issues


## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

