### PR TITLE
Launch basler camera with vision

### DIFF
--- a/bitbots_vision/launch/vision_startup.launch
+++ b/bitbots_vision/launch/vision_startup.launch
@@ -4,8 +4,6 @@
     <arg name="camera" default="true" description="true: launches an image provider to get images from a camera (unless sim:=true)" />
     <arg name="debug" default="false" description="true: activates publishing of several debug images" />
 
-    <!-- TODO add camera driver -->
-
     <let if="$(env IS_ROBOT false)" name="taskset" value="taskset -c 6,7"/>
     <let unless="$(env IS_ROBOT false)" name="taskset" value=""/>
 
@@ -37,5 +35,12 @@
             <!-- Use sim time-->
             <param name="use_sim_time" value="true"/>
         </node>
+    </group>
+
+    <!-- Start the camera only when necessary -->
+    <group if="$(var camera)">
+        <group unless="$(var sim)">
+            <include file="$(find-pkg-share bitbots_basler_camera)/launch/basler_camera.launch" />
+        </group>
     </group>
 </launch>

--- a/bitbots_vision/package.xml
+++ b/bitbots_vision/package.xml
@@ -34,8 +34,7 @@
   <depend>python3-opencv</depend>
   <depend>soccer_vision_2d_msgs</depend>
   <depend>humanoid_league_msgs</depend>
-
-
+  <depend>bitbots_basler_camera</depend>
 
   <export>
     <bitbots_documentation>


### PR DESCRIPTION
## Proposed changes
Reintroduce launch parameter `camera` (defaults to true) to launch the Basler camera alongside the vision.

## Related issues

## Necessary checks
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Put the PR on our Project board

