### PR TITLE
Remove basler camera dependency

### DIFF
--- a/bitbots_vision/package.xml
+++ b/bitbots_vision/package.xml
@@ -34,7 +34,6 @@
   <depend>python3-opencv</depend>
   <depend>soccer_vision_2d_msgs</depend>
   <depend>humanoid_league_msgs</depend>
-  <depend>bitbots_basler_camera</depend>
 
   <export>
     <bitbots_documentation>


### PR DESCRIPTION
## Proposed changes
Remove basler camera dependency as we want to to build the vision without camera drivers installed

## Related issues
bit-bots/bitbots_misc/pull/157

## Necessary checks
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Put the PR on our Project board

