### PR TITLE
Vision launch: Remove camera driver launch

### DIFF
--- a/bitbots_vision/docs/index.rst
+++ b/bitbots_vision/docs/index.rst
@@ -54,7 +54,7 @@ To start the vision, use
 
 ::
 
-   roslaunch bitbots_vision vision_startup.launch
+   roslaunch bitbots_vision vision.launch
 
 The following parameters are available:
 
@@ -63,15 +63,7 @@ The following parameters are available:
 +=====================+=========+===========================================================================================================================+
 |``sim``              |``false``|Activate simulation time, switch to simulation color settings and deactivate launching of an image provider                |
 +---------------------+---------+---------------------------------------------------------------------------------------------------------------------------+
-|``camera``           |``true`` |Deactivate all image providers (e.g. for use with rosbags or in simulation)                                                |
-+---------------------+---------+---------------------------------------------------------------------------------------------------------------------------+
-|``basler``           |``true`` |Start the basler camera driver instead of the  `wolves_image_provider <https://github.com/bit-bots/wolves_image_provider>`_|
-+---------------------+---------+---------------------------------------------------------------------------------------------------------------------------+
-|``dummyball``        |``false``|NOT start the ball detection to save resources                                                                             |
-+---------------------+---------+---------------------------------------------------------------------------------------------------------------------------+
 |``debug``            |``false``|Activate publishing of several debug images which can be inspected in the rqt image view                                   |
-+---------------------+---------+---------------------------------------------------------------------------------------------------------------------------+
-|``use_game_settings``|``false``|Load additional game settings                                                                                              |
 +---------------------+---------+---------------------------------------------------------------------------------------------------------------------------+
 
 

--- a/bitbots_vision/launch/vision.launch
+++ b/bitbots_vision/launch/vision.launch
@@ -1,7 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
 <launch>
     <!-- Get launch params-->
     <arg name="sim" default="false" description="true: activates simulation time, switches to simulation color settings and deactivates launching of an image provider" />
-    <arg name="camera" default="true" description="true: launches an image provider to get images from a camera (unless sim:=true)" />
     <arg name="debug" default="false" description="true: activates publishing of several debug images" />
 
     <let if="$(env IS_ROBOT false)" name="taskset" value="taskset -c 6,7"/>
@@ -35,12 +35,5 @@
             <!-- Use sim time-->
             <param name="use_sim_time" value="true"/>
         </node>
-    </group>
-
-    <!-- Start the camera only when necessary -->
-    <group if="$(var camera)">
-        <group unless="$(var sim)">
-            <include file="$(find-pkg-share bitbots_basler_camera)/launch/basler_camera.launch" />
-        </group>
     </group>
 </launch>


### PR DESCRIPTION
## Proposed changes
Vision launch: Remove camera driver launch
Does not start camera anymore.
This was moved to bitbots_bringup vision_standalone.launch

## Related issues
bit-bots/bitbots_misc/pull/159
bit-bots/bitbots_behavior/pull/261

## Necessary checks
- [ ] Run `catkin build`
- [x] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Put the PR on our Project board

