### PR TITLE
Fix tvm typehint for when it is not installed

### DIFF
--- a/bitbots_vision/bitbots_vision/vision_modules/yoeo_handler.py
+++ b/bitbots_vision/bitbots_vision/vision_modules/yoeo_handler.py
@@ -383,7 +383,7 @@ class YOEOHandlerTVM(YOEOHandlerTemplate):
         logger.debug(f"Leaving {self.__class__.__name__} constructor")
 
     @staticmethod
-    def _select_device() -> tvm.runtime.Device:
+    def _select_device() -> "tvm.runtime.Device":
         if tvm.vulkan().exist:
             return tvm.vulkan()
         else:


### PR DESCRIPTION
String typehints also work, but otherwise it fails at import time when tvm is not installed.