### PR TITLE
global variable "own_team_color" was updated too late in YOEOVision constructor

### DIFF
--- a/bitbots_vision/bitbots_vision/yoeo_vision.py
+++ b/bitbots_vision/bitbots_vision/yoeo_vision.py
@@ -53,10 +53,10 @@ class YOEOVision(Node):
         # Add general params
         ros_utils.set_general_parameters(["caching"])
 
-        self._dynamic_reconfigure_callback(self.get_parameters_by_prefix("").values())
-
         # Update team color
         ros_utils.update_own_team_color(self)
+
+        self._dynamic_reconfigure_callback(self.get_parameters_by_prefix("").values())
 
         logger.debug(f"Leaving {self.__class__.__name__} constructor")
 

--- a/bitbots_vision/package.xml
+++ b/bitbots_vision/package.xml
@@ -8,7 +8,7 @@
     For further information and getting started, see the documentation of this package at our website: http://doku.bit-bots.de/package/bitbots_vision/latest/index.html
   </description>
 
-  <version>1.4.0</version>
+  <version>1.4.1</version>
 
   <maintainer email="7vahl@informatik.uni-hamburg.de">Florian Vahl</maintainer>
   <maintainer email="7gutsche@informatik.uni-hamburg.de">Jan Gutsche</maintainer>


### PR DESCRIPTION
global variable "own_team_color" was updated too late in YOEOVision constructor leading to vision components being initialized with "None" instead of the actual team color

## Necessary checks
- [x] Update package version


