### PR TITLE
Remove additional rclpy.shutdown()

### DIFF
--- a/bitbots_vision/bitbots_vision/yoeo_vision.py
+++ b/bitbots_vision/bitbots_vision/yoeo_vision.py
@@ -187,4 +187,3 @@ def main(args=None):
     except KeyboardInterrupt:
         pass
     node.destroy_node()
-    rclpy.shutdown()


### PR DESCRIPTION
Currently we get the error `rclpy._rclpy_pybind11.RCLError: failed to shutdown: rcl_shutdown already called on the given context` after pressing Ctrl-C.