### PR TITLE
Cleanup/remove record bag

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is the vision ROS package of the Hamburg Bit-Bots.
 
 The vision is able to detect balls, lines, the field itself, the field boundary, goal posts, teammates, enemies and other obstacles.
 
-For further information and getting started, see the documentation of this package at our website: [doku.bit-bots.de](http://doku.bit-bots.de/package/bitbots_vision/latest/index.html)
+For further information and getting started, see the documentation of this package at our website: [docs.bit-bots.de](https://docs.bit-bots.de/package/bitbots_vision/latest/index.html)
 
 An earlier version of this pipeline is presented in our paper [An Open Source Vision Pipeline Approach for RoboCup Humanoid Soccer](https://robocup.informatik.uni-hamburg.de/wp-content/uploads/2019/06/vision_paper.pdf).
 When you use this pipeline or parts of it, please cite it.

--- a/bitbots_vision/launch/record_bag.launch
+++ b/bitbots_vision/launch/record_bag.launch
@@ -1,7 +1,0 @@
-<launch>
-    <arg name="camera" default="true" description="true: launches an image provider to get images from a camera" />
-
-    <include if="$(arg camera)" file="$(find bitbots_bringup)/launch/basler_camera.launch" />
-
-    <executable cmd="ros2 bag record -o /tmp/tmpbag.bag camera/image_proc camera_info" output="screen" />
-</launch>


### PR DESCRIPTION
# Summary
In #332 initially, we wanted to move the launch file to the `bitbots_basler_camera` package.
Then I noticed, that the static output file in `/tmp/` is not ideal, therefore tried to copy and adapt the large `rosbag_record.launch.py`.
Finally, I decided that would be too much effort, as we can just use that launch script or the simple CLI `ros2 bag record`.

## Proposed changes
- Removes old `record_bag.launch` file.
- Also updates documentation link in README.

## Related issues
Resolves #332

## Checklist

- [ ] Run `colcon build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [X] This PR is on our `Software` project board
